### PR TITLE
fix: Set width to auto in the markdown box when creating an entry

### DIFF
--- a/lib/public/views/Logs/Create/index.js
+++ b/lib/public/views/Logs/Create/index.js
@@ -63,7 +63,7 @@ const createScreen = (model) => {
             }, title),
         ]),
         h('h3.black.line-break: auto', 'Text'),
-        h('.shadow-level2.w-90', mdBox(model, text)),
+        h('.shadow-level2.w-100', mdBox(model, text)),
         h('button.mv2.shadow-level1.btn.btn-success.m#send', {
             onclick: () => model.logs.createLog(),
             disabled,

--- a/lib/public/views/Logs/Create/index.js
+++ b/lib/public/views/Logs/Create/index.js
@@ -21,7 +21,7 @@ import { h } from '/js/src/index.js';
 const mdBox = (model, text) => h('', {
     onremove: () => model.logs.flushModel(),
 }, [
-    h('textarea#text.w-75.form-control', {
+    h('textarea#text.form-control', {
         placeholder: 'Your message...',
         disabled: true,
         onchange: (e) => model.logs.setText(e.target.value),
@@ -63,7 +63,7 @@ const createScreen = (model) => {
             }, title),
         ]),
         h('h3.black.line-break: auto', 'Text'),
-        h('.shadow-level2', mdBox(model, text)),
+        h('.shadow-level2.w-90', mdBox(model, text)),
         h('button.mv2.shadow-level1.btn.btn-success.m#send', {
             onclick: () => model.logs.createLog(),
             disabled,

--- a/lib/public/views/Logs/Logs.js
+++ b/lib/public/views/Logs/Logs.js
@@ -388,7 +388,7 @@ export default class Overview extends Observable {
         const { isReadOnly, textValue } = readOnlyProperties;
         const shouldRenderReadOnly = textValue && isReadOnly;
         const mdBoxStyling = shouldRenderReadOnly ?
-            { width: 'auto', height: 'auto' } : { width: '80rem', height: '40rem' };
+            { width: 'auto', height: 'auto' } : { width: 'auto', height: '40rem' };
 
         !this.isPreviewActive && setTimeout(() => {
             this.editor = setMarkDownBox(textAreaId, this.model, changeHandler, isReadOnly, mdBoxStyling);


### PR DESCRIPTION
Instructions to verify: Go to the create screen and create a title like: # Sample Text, hit enter and the grey line should cover the whole width of the box now