### PR TITLE
Updated wait-for-it.sh

### DIFF
--- a/scripts/wait-for-it.sh
+++ b/scripts/wait-for-it.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#   Use this script to test if a given TCP host/port are available
+# Use this script to test if a given TCP host/port are available
 
 WAITFORIT_cmdname=${0##*/}
 
@@ -36,7 +36,7 @@ wait_for()
             nc -z $WAITFORIT_HOST $WAITFORIT_PORT
             WAITFORIT_result=$?
         else
-            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
             WAITFORIT_result=$?
         fi
         if [[ $WAITFORIT_result -eq 0 ]]; then
@@ -141,16 +141,20 @@ WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
 WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
 WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
 
-# check to see if timeout is from busybox?
+# Check to see if timeout is from busybox?
 WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
 WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
-if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
-        WAITFORIT_ISBUSY=1
-        WAITFORIT_BUSYTIMEFLAG="-t"
 
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
 else
-        WAITFORIT_ISBUSY=0
-        WAITFORIT_BUSYTIMEFLAG=""
+    WAITFORIT_ISBUSY=0
 fi
 
 if [[ $WAITFORIT_CHILD -gt 0 ]]; then


### PR DESCRIPTION
echo sends a newline character which causes some server software to report an error message about an invalid HTTP request. By adding the '-n' flag the echo command can be used to open the port without sending anything.