### PR TITLE
feat: feat: create dropdown for lists of attachments and truncate lon…

### DIFF
--- a/lib/public/Model.js
+++ b/lib/public/Model.js
@@ -78,6 +78,9 @@ export default class Model extends Observable {
 
         // Navbar dropdown menus
         this.dropdownMenu = false;
+
+        // Log's dropdown attachments
+        this.dropdownAttachments = false;
     }
 
     /**
@@ -173,6 +176,24 @@ export default class Model extends Observable {
      */
     toggleOverviewDropdown() {
         this.dropdownMenu = this.dropdownMenu === 'overview' ? false : 'overview';
+        this.notify();
+    }
+
+    /**
+     * Toggle log's attachments dropdown
+     * @returns {undefined}
+     */
+    toggleAttachmentsDropdown() {
+        this.dropdownAttachments = this.dropdownAttachments === 'attachments' ? false : 'attachments';
+        this.notify();
+    }
+
+    /**
+     * Clears attachments dropdown
+     * @returns {undefined}
+     */
+    clearAttachmentDropdown() {
+        this.dropdownAttachments = false;
         this.notify();
     }
 

--- a/lib/public/app.css
+++ b/lib/public/app.css
@@ -179,7 +179,7 @@ html, body {
     display: block;
 }
 
-.navbar-dropdown {
+.navbar-dropdown, .attachments-dropdown {
     position: relative;
 }
 
@@ -226,4 +226,27 @@ html, body {
 
 .gray-dark {
     color: var(--color-gray-dark) !important;
+}
+
+.attachments-dropdown .dropdown-menu {
+    top: 100%;
+    right: auto;
+    left: 0;
+    min-height: auto;
+    max-height: 30vh;
+    margin-top: 0.25rem;
+    margin-left: 0.125rem;
+    overflow-y: auto;
+}
+
+.attachments-dropdown .dropdown-menu .menu-item:hover {
+    background-color: var(--color-white);
+}
+
+.menu-item--truncated {
+    display: inline-block;
+    width: 12rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }

--- a/lib/public/components/Post/index.js
+++ b/lib/public/components/Post/index.js
@@ -12,20 +12,68 @@
  */
 
 import { h } from '/js/src/index.js';
+import { iconPaperclip } from '/js/src/icons.js';
+
+const MAX_MENUITEM_TEXT_LENGTH = 50;
+const MAX_ATTACHMENTS_WITHOUT_DROPDOWN = 5;
+
+/**
+ * A generic generator to create an element with text truncated by ellipsis
+ * @param {String} tag (DOM) to create an element
+ * @param {Object} properties to create properties for a specific element
+ * @param {String} text for an element
+ * @return {vnode} a html node with text truncated by ellipsis
+ */
+const truncatedMenuItem = (tag, properties, text) => [
+    h(tag, {
+        ...properties,
+        class: 'menu-item--truncated',
+        title: text,
+    }, text),
+];
 
 /**
  * A generic generator function to create a list of custom links based on custom defined properties
  * @param {Array} links The collection of objects from which to generate links
  * @param {Function} properties A function to create link properties for a specific link
  * @param {String} textKey The object key to inherit the link's name from in an array entry
- * @return {vnode} A collection of links seperated by commas
+ * @return {vnode} A collection of links separated by commas
  */
-const linksContainer = (links, properties, textKey) => links.length > 0
-    ? h('.flex-wrap', { style: 'word-break: break-all' }, links.map((link, index) => h('.flex-row', [
-        h('a', properties(link), link[textKey]),
-        index + 1 < links.length ? h('', { style: 'white-space: pre;' }, ', ') : null,
-    ])))
-    : 'None';
+const linksContainer = (links, properties, textKey) =>
+    links.length > 0
+        ? h('.flex-wrap', { style: 'word-break: break-all' }, links.map((link, index) =>
+            h('.flex-row', link[textKey].length < MAX_MENUITEM_TEXT_LENGTH ? [
+                h('a', properties(link), link[textKey]),
+                index + 1 < links.length
+                    ? h('', { style: 'white-space: pre;' }, ', ')
+                    : null,
+            ] : truncatedMenuItem('a', properties(link), link[textKey]))))
+        : 'None';
+
+/**
+ * Returns a dropdown for multiple attachments.
+ * @param {Object} model Pass the model to access the defined functions.
+ * @param {Array} links The collection of objects from which to generate links
+ * @param {Function} properties A function to create link properties for a specific link
+ * @param {String} textKey The object key to inherit the link's name from in an array entry
+ * @return {vnode} A dropdown with given list of links
+ */
+const attachmentsDropdown = (model, links, properties, textKey) =>
+    h('.attachments-dropdown', {
+        class: model.dropdownAttachments === 'attachments' ? 'dropdown-open' : '',
+        onremove: () => model.clearAttachmentDropdown(),
+    }, [
+        h('.flex-wrap.btn', {
+            id: 'attachments-btn',
+            onclick: () => model.toggleAttachmentsDropdown(),
+        }, iconPaperclip()),
+        h('.dropdown-menu', { style: 'width: max-content' }, [
+            links.map((link) =>
+                h('.flex-row.menu-item', link[textKey].length < MAX_MENUITEM_TEXT_LENGTH
+                    ? [h('a', properties(link), link[textKey])]
+                    : truncatedMenuItem('a', properties(link), link[textKey]))),
+        ]),
+    ]);
 
 /**
  * A collection of fields to show per log detail, optionally with special formatting
@@ -76,9 +124,16 @@ const activeFields = (model) => ({
     attachments: {
         name: 'Attachments',
         visible: true,
-        format: (attachments) => linksContainer(attachments, ({ id, fileName }) => (
-            { href: `/api/attachments/${id}`, download: fileName }
-        ), 'originalName'),
+        format: (attachments) =>
+            attachments.length > MAX_ATTACHMENTS_WITHOUT_DROPDOWN
+                ? attachmentsDropdown(model, attachments, ({ id, fileName }) => ({
+                    href: `/api/attachments/${id}`,
+                    download: fileName,
+                }), 'originalName')
+                : linksContainer(attachments, ({ id, fileName }) => ({
+                    href: `/api/attachments/${id}`,
+                    download: fileName,
+                }), 'originalName'),
     },
 });
 


### PR DESCRIPTION
If attachments number is more than 5, create a attachment's button. 
Click button to open dropdown with list of attachments. 
Long attachment's name in simple list and dropdown is truncate with ellipsis.