### PR TITLE
Refactored Puppeteer calls in the test suite

### DIFF
--- a/test/public/flps/detail.test.js
+++ b/test/public/flps/detail.test.js
@@ -68,7 +68,7 @@ module.exports = () => {
 
     it('flp detail loads correctly', async () => {
         await page.goto(`${url}/?page=flp-detail&id=1`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         const postExists = await page.$('h2');
         expect(Boolean(postExists)).to.be.true;
@@ -79,21 +79,21 @@ module.exports = () => {
 
     it('can navigate to the log panel', async () => {
         await page.click('#logs-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=flp-detail&id=1&panel=logs`)).to.be.true;
     });
 
     it('can navigate to the main panel', async () => {
         await page.click('#main-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=flp-detail&id=1&panel=main`)).to.be.true;
     });
 
     it('can navigate to the log panel', async () => {
         await page.click('#logs-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=flp-detail&id=1&panel=logs`)).to.be.true;
     });
@@ -104,7 +104,7 @@ module.exports = () => {
 
         // We expect the entry page to have the same id as the id from the flp overview
         await page.click(`#${firstRowId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=log-detail&id=1`)).to.be.true;
     });
@@ -112,7 +112,7 @@ module.exports = () => {
     it('notifies if a specified flp id is invalid', async () => {
         // Navigate to a flp detail view with an id that cannot exist
         await page.goto(`${url}/?page=flp-detail&id=abc`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be an error message
         const error = await page.$('.alert');
@@ -124,7 +124,7 @@ module.exports = () => {
     it('notifies if a specified flp id is not found', async () => {
         // Navigate to a flp detail view with an id that cannot exist
         await page.goto(`${url}/?page=flp-detail&id=999`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be an error message
         const error = await page.$('.alert');
@@ -141,7 +141,7 @@ module.exports = () => {
 
         // We expect the button to return the user to the overview page when pressed
         await returnButton.click();
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=flp-overview`)).to.be.true;
     });

--- a/test/public/flps/detail.test.js
+++ b/test/public/flps/detail.test.js
@@ -67,8 +67,7 @@ module.exports = () => {
     });
 
     it('flp detail loads correctly', async () => {
-        await page.goto(`${url}/?page=flp-detail&id=1`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=flp-detail&id=1`, { waitUntil: 'networkidle0' });
 
         const postExists = await page.$('h2');
         expect(Boolean(postExists)).to.be.true;
@@ -111,8 +110,7 @@ module.exports = () => {
 
     it('notifies if a specified flp id is invalid', async () => {
         // Navigate to a flp detail view with an id that cannot exist
-        await page.goto(`${url}/?page=flp-detail&id=abc`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=flp-detail&id=abc`, { waitUntil: 'networkidle0' });
 
         // We expect there to be an error message
         const error = await page.$('.alert');
@@ -123,8 +121,7 @@ module.exports = () => {
 
     it('notifies if a specified flp id is not found', async () => {
         // Navigate to a flp detail view with an id that cannot exist
-        await page.goto(`${url}/?page=flp-detail&id=999`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=flp-detail&id=999`, { waitUntil: 'networkidle0' });
 
         // We expect there to be an error message
         const error = await page.$('.alert');

--- a/test/public/flps/overview.test.js
+++ b/test/public/flps/overview.test.js
@@ -70,7 +70,7 @@ module.exports = () => {
 
     it('loads the page successfully', async () => {
         const response = await page.goto(`${url}?page=flp-overview`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect the page to return the correct status code, making sure the server is running properly
         expect(response.status()).to.equal(200);
@@ -126,14 +126,14 @@ module.exports = () => {
 
         // Expect the dropdown options to be visible when it is selected
         await amountSelectorButton.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const amountSelectorDropdown = await page.$(`${amountSelectorId} .dropdown-menu`);
         expect(Boolean(amountSelectorDropdown)).to.be.true;
 
         // Expect the amount of visible flps to reduce when the first option (5) is selected
         const menuItem = await page.$(`${amountSelectorId} .dropdown-menu .menu-item`);
         await menuItem.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         const tableRows = await page.$$('table tr');
         expect(tableRows.length - 1).to.equal(5);
@@ -151,7 +151,7 @@ module.exports = () => {
         const oldFirstRowId = await getFirstRow(table, page);
         const secondPage = await page.$('#page2');
         await secondPage.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         table = await page.$$('tr');
         const newFirstRowId = await getFirstRow(table, page);
         expect(oldFirstRowId).to.not.equal(newFirstRowId);
@@ -159,7 +159,7 @@ module.exports = () => {
         // Expect us to be able to do the same with the page arrows
         const prevPage = await page.$('#pageMoveLeft');
         await prevPage.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const oldFirstPageButton = await page.$('#page1');
         const oldFirstPageButtonClass = await page.evaluate((element) => element.className, oldFirstPageButton);
         expect(oldFirstPageButtonClass).to.include('selected');
@@ -167,7 +167,7 @@ module.exports = () => {
         // The same, but for the other (right) arrow
         const nextPage = await page.$('#pageMoveRight');
         await nextPage.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const newFirstPageButton = await page.$('#page1');
         const newFirstPageButtonClass = await page.evaluate((element) => element.className, newFirstPageButton);
         expect(newFirstPageButtonClass).to.not.include('selected');
@@ -179,7 +179,7 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.flps.setFlpsPerPage(1);
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the page five button to now be visible, but no more than that
         const pageFiveButton = await page.$('#page5');
@@ -189,7 +189,7 @@ module.exports = () => {
 
         // Expect the page one button to have fallen away when clicking on page five button
         await page.click('#page5');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const pageOneButton = await page.$('#page1');
         expect(Boolean(pageOneButton)).to.be.false;
     });
@@ -203,7 +203,7 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.flps.setFlpsPerPage(200);
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be a fitting error message
         const error = await page.$('.alert-danger');
@@ -216,7 +216,7 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.flps.setFlpsPerPage(10);
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
     });
 
     it('can navigate to a flp detail page', async () => {
@@ -226,7 +226,7 @@ module.exports = () => {
 
         // We expect the entry page to have the same id as the id from the flp overview
         await page.click(`#${firstRowId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=flp-detail&id=${parsedFirstRowId}`)).to.be.true;
     });

--- a/test/public/flps/overview.test.js
+++ b/test/public/flps/overview.test.js
@@ -69,8 +69,7 @@ module.exports = () => {
     });
 
     it('loads the page successfully', async () => {
-        const response = await page.goto(`${url}?page=flp-overview`);
-        await page.waitForTimeout(100);
+        const response = await page.goto(`${url}?page=flp-overview`, { waitUntil: 'networkidle0' });
 
         // We expect the page to return the correct status code, making sure the server is running properly
         expect(response.status()).to.equal(200);

--- a/test/public/logs/create.test.js
+++ b/test/public/logs/create.test.js
@@ -69,8 +69,7 @@ module.exports = () => {
     });
 
     it('correctly loads the log creation page', async () => {
-        await page.goto(`${url}/?page=log-create`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=log-create`, { waitUntil: 'networkidle0' });
 
         // We expect the log creation screen to be shown correctly
         const header = await page.$('h2');

--- a/test/public/logs/create.test.js
+++ b/test/public/logs/create.test.js
@@ -70,7 +70,7 @@ module.exports = () => {
 
     it('correctly loads the log creation page', async () => {
         await page.goto(`${url}/?page=log-create`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect the log creation screen to be shown correctly
         const header = await page.$('h2');
@@ -98,12 +98,12 @@ module.exports = () => {
         // Create the new log
         const buttonSend = await page.$('button#send');
         await buttonSend.evaluate((button) => button.click());
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Return the page to home
         const buttonHome = await page.$('#log-overview');
         await buttonHome.evaluate((button) => button.click());
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Ensure you are at the overview page again
         const redirectedUrl = await page.url();
@@ -115,7 +115,7 @@ module.exports = () => {
         const firstRowTitle = await page.$(`#${firstRowId}-title-text`);
         const titleText = await firstRowTitle.evaluate((element) => element.innerText);
         expect(titleText).to.equal(title);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
     });
 
     it('can collapse and expand logs with long titles', async () => {
@@ -127,7 +127,7 @@ module.exports = () => {
         const expandButton = await page.$(`#${firstRowId}-title-plus`);
         expect(Boolean(expandButton)).to.be.true;
         await expandButton.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         const expandedTitle = await page.$(`#${firstRowId}-title`);
         const expandedTitleHeight = await page.evaluate((element) => element.clientHeight, expandedTitle);
@@ -135,7 +135,7 @@ module.exports = () => {
         const collapseButton = await page.$(`#${firstRowId}-title-minus`);
         expect(Boolean(collapseButton)).to.be.true;
         await collapseButton.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         const collapsedTitle = await page.$(`#${firstRowId}-title`);
         const collapsedTitleHeight = await page.evaluate((element) => element.clientHeight, collapsedTitle);
@@ -150,9 +150,9 @@ module.exports = () => {
 
         // Return to the creation page
         await page.click('#log-overview');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
         await page.click('#create');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Select the boxes and send the values of the title and text to it
         await page.type('#title', title);
@@ -182,12 +182,12 @@ module.exports = () => {
         // Create the new log
         const buttonSend = await page.$('button#send');
         await buttonSend.evaluate((button) => button.click());
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Return the page to home
         const buttonHome = await page.$('#log-overview');
         await buttonHome.evaluate((button) => button.click());
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Get the latest post and verify that the selected tags correspond to the posted tags
         const table = await page.$$('tr');
@@ -200,14 +200,14 @@ module.exports = () => {
     it('can navigate to tag creation screen', async () => {
         // Return to the creation page
         await page.click('#log-overview');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
         await page.click('#create');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Expect the user to be at the tag creation screen when the URL is clicked on
         const tagCreationLink = await page.$('#tagCreateLink');
         await page.evaluate((button) => button.click(), tagCreationLink);
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
         const redirectedUrl = await page.url();
         expect(redirectedUrl).to.equal(`${url}/?page=tag-create`);
     });
@@ -220,9 +220,9 @@ module.exports = () => {
 
         // Return to the creation page
         await page.click('#log-overview');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
         await page.click('#create');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Select the boxes and send the values of the title and text to it
         await page.type('#title', title);
@@ -234,7 +234,7 @@ module.exports = () => {
         const file1Path = path.resolve(__dirname, '../..', 'assets', file1);
         const file2Path = path.resolve(__dirname, '../..', 'assets', file2);
         attachmentsInput.uploadFile(file1Path, file2Path);
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Ensure that both file attachments were received
         const attachmentNames = await page.$('#attachmentNames');
@@ -245,12 +245,12 @@ module.exports = () => {
         const buttonSend = await page.$('button#send');
         await buttonSend.evaluate((button) => button.click());
         // Sizable delay to allow for file uploading
-        await page.waitFor(2500);
+        await page.waitForTimeout(2500);
 
         // Return the page to home
         const buttonHome = await page.$('#log-overview');
         await buttonHome.evaluate((button) => button.click());
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Get the latest post and verify the title of the log we posted
         const table = await page.$$('tr');
@@ -267,7 +267,7 @@ module.exports = () => {
         // Go to the log detail page
         const row = await page.$(`tr#${firstRowId}`);
         await row.evaluate((row) => row.click());
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Verify that the attachment names match the ones we uploaded
         const parsedFirstRowId = parseInt(firstRowId.slice('row'.length, firstRowId.length), 10);
@@ -279,9 +279,9 @@ module.exports = () => {
     it('can clear the file attachment input if at least one is submitted', async () => {
         // Return to the creation page
         await page.click('#log-overview');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
         await page.click('#create');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // We expect the clear button to not be visible yet
         let clearButton = await page.$('#clearAttachments');
@@ -290,7 +290,7 @@ module.exports = () => {
         // Add a single file attachment to the input field
         const attachmentsInput = await page.$('#attachments');
         attachmentsInput.uploadFile(path.resolve(__dirname, '../..', 'assets', '1200px-CERN_logo.png'));
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // We expect the clear button to appear
         clearButton = await page.$('#clearAttachments');
@@ -301,7 +301,7 @@ module.exports = () => {
         expect(uploadedAttachments.endsWith('1200px-CERN_logo.png')).to.be.true;
 
         await clearButton.evaluate((clearButton) => clearButton.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const newUploadedAttachments = await page.evaluate((element) => element.value, attachmentsInput);
         expect(newUploadedAttachments).to.equal('');
     });
@@ -313,9 +313,9 @@ module.exports = () => {
 
         // Return to the creation page
         await page.click('#log-overview');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
         await page.click('#create');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Select the boxes and send the values of the title and text to it
         await page.type('#title', title);
@@ -328,12 +328,12 @@ module.exports = () => {
         // Create the new log
         const buttonSend = await page.$('button#send');
         await buttonSend.evaluate((button) => button.click());
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Return the page to home
         const buttonHome = await page.$('#log-overview');
         await buttonHome.evaluate((button) => button.click());
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Find the created log
         const table = await page.$$('tr');
@@ -345,7 +345,7 @@ module.exports = () => {
         // Go to the log detail page
         const row = await page.$(`tr#${firstRowId}`);
         await row.evaluate((row) => row.click());
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Verify that the runs are linked to the log
         const parsedFirstRowId = parseInt(firstRowId.slice('row'.length, firstRowId.length), 10);
@@ -362,9 +362,9 @@ module.exports = () => {
 
         // Return to the creation page
         await page.click('#log-overview');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
         await page.click('#create');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Select the boxes and send the values of the title and text to it
         await page.type('#title', title);
@@ -377,12 +377,12 @@ module.exports = () => {
         // Create the new log
         const buttonSend = await page.$('button#send');
         await buttonSend.evaluate((button) => button.click());
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Return the page to home
         const buttonHome = await page.$('#log-overview');
         await buttonHome.evaluate((button) => button.click());
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Find the created log
         const table = await page.$$('tr');
@@ -394,7 +394,7 @@ module.exports = () => {
         // Go to the log detail page
         const row = await page.$(`tr#${firstRowId}`);
         await row.evaluate((row) => row.click());
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Verify that the runs are linked to the log
         const parsedFirstRowId = parseInt(firstRowId.slice('row'.length, firstRowId.length), 10);

--- a/test/public/logs/detail.test.js
+++ b/test/public/logs/detail.test.js
@@ -46,8 +46,7 @@ module.exports = () => {
     });
 
     it('log detail loads correctly', async () => {
-        await page.goto(`${url}/?page=log-detail&id=1`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=log-detail&id=1`, { waitUntil: 'networkidle0' });
 
         // We expect there to be at least one post in this log entry
         const postExists = await page.$('#post1');
@@ -56,8 +55,7 @@ module.exports = () => {
 
     it('notifies if a specified log id is invalid', async () => {
         // Navigate to a log detail view with an id that cannot exist
-        await page.goto(`${url}/?page=log-detail&id=99999999`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=log-detail&id=99999999`, { waitUntil: 'networkidle0' });
 
         // We expect there to be an error message
         const error = await page.$('.alert-danger');
@@ -71,8 +69,7 @@ module.exports = () => {
         const runId = 1;
 
         // Navigate to a log detail view
-        await page.goto(`${url}/?page=log-detail&id=${logId}`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=log-detail&id=${logId}`, { waitUntil: 'networkidle0' });
 
         // We expect the correct associated runs to be shown
         const runField = await page.$(`#post${logId}-runs`);
@@ -91,8 +88,7 @@ module.exports = () => {
 
     it('should have a button to reply on a entry', async () => {
         const parentLogId = 2;
-        await page.goto(`${url}/?page=log-detail&id=${parentLogId}`);
-        await page.waitForTimeout(250);
+        await page.goto(`${url}/?page=log-detail&id=${parentLogId}`, { waitUntil: 'networkidle0' });
 
         // We expect there to be at least one post in this log entry
         await page.click(`#reply-to-${parentLogId}`);

--- a/test/public/logs/detail.test.js
+++ b/test/public/logs/detail.test.js
@@ -47,7 +47,7 @@ module.exports = () => {
 
     it('log detail loads correctly', async () => {
         await page.goto(`${url}/?page=log-detail&id=1`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be at least one post in this log entry
         const postExists = await page.$('#post1');
@@ -57,7 +57,7 @@ module.exports = () => {
     it('notifies if a specified log id is invalid', async () => {
         // Navigate to a log detail view with an id that cannot exist
         await page.goto(`${url}/?page=log-detail&id=99999999`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be an error message
         const error = await page.$('.alert-danger');
@@ -72,7 +72,7 @@ module.exports = () => {
 
         // Navigate to a log detail view
         await page.goto(`${url}/?page=log-detail&id=${logId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect the correct associated runs to be shown
         const runField = await page.$(`#post${logId}-runs`);
@@ -82,7 +82,7 @@ module.exports = () => {
         // We expect the associated runs to be clickable with a valid link
         const runLink = await page.$(`#post${logId}-runs a`);
         await runLink.click();
-        await page.waitFor(1000);
+        await page.waitForTimeout(1000);
 
         // We expect the link to navigate to the correct run detail page
         const redirectedUrl = await page.url();
@@ -92,11 +92,11 @@ module.exports = () => {
     it('should have a button to reply on a entry', async () => {
         const parentLogId = 2;
         await page.goto(`${url}/?page=log-detail&id=${parentLogId}`);
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // We expect there to be at least one post in this log entry
         await page.click(`#reply-to-${parentLogId}`);
-        await page.waitFor(1000);
+        await page.waitForTimeout(1000);
 
         const redirectedUrl = await page.url();
         expect(redirectedUrl).to.equal(`${url}/?page=log-create&parentLogId=${parentLogId}`);
@@ -107,12 +107,12 @@ module.exports = () => {
         await page.type('#title', title);
         // eslint-disable-next-line no-undef
         await page.evaluate((text) => model.logs.editor.setValue(text), text);
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Create the new log
         const button = await page.$('button#send');
         await button.evaluate((button) => button.click());
-        await page.waitFor(1000);
+        await page.waitForTimeout(1000);
 
         // Expect to be redirected to the new log
         const postSendUrl = await page.url();

--- a/test/public/logs/overview.test.js
+++ b/test/public/logs/overview.test.js
@@ -89,8 +89,7 @@ module.exports = () => {
     });
 
     it('loads the page successfully', async () => {
-        const response = await page.goto(url);
-        await page.waitForTimeout(100);
+        const response = await page.goto(url, { waitUntil: 'networkidle0' });
 
         // We expect the page to return the correct status code, making sure the server is running properly
         expect(response.status()).to.equal(200);

--- a/test/public/logs/overview.test.js
+++ b/test/public/logs/overview.test.js
@@ -90,7 +90,7 @@ module.exports = () => {
 
     it('loads the page successfully', async () => {
         const response = await page.goto(url);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect the page to return the correct status code, making sure the server is running properly
         expect(response.status()).to.equal(200);
@@ -108,11 +108,11 @@ module.exports = () => {
 
         // Open the title filter
         await page.click('#titleFilterToggle');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Insert some text into the filter
         await page.type('#titleFilterText', 'entry');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Expect the (new) total number of rows to be less than the original number of rows
         const firstFilteredRows = await page.$$('table tr');
@@ -121,7 +121,7 @@ module.exports = () => {
 
         // Insert some other text into the filter
         await page.type('#titleFilterText', ' bogusbogusbogus');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Expect the table to be empty
         const secondFilteredRows = await page.$$('table tr');
@@ -133,7 +133,7 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.logs.resetLogsParams();
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the total number of rows to once more equal the original total
         const unfilteredRows = await page.$$('table tr');
@@ -142,7 +142,7 @@ module.exports = () => {
 
         // Close the created at filters now that we are done with them
         await page.click('#titleFilterToggle');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
     });
 
     it('can filter by log author', async () => {
@@ -153,11 +153,11 @@ module.exports = () => {
 
         // Open the author filter
         await page.click('#authorFilterToggle');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Insert some text into the filter
         await page.type('#authorFilterText', 'John');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Expect the (new) total number of rows to be less than the original number of rows
         const firstFilteredRows = await page.$$('table tr');
@@ -166,7 +166,7 @@ module.exports = () => {
 
         // Insert some other text into the filter
         await page.type('#authorFilterText', ' DoesNotExist');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Expect the table to be empty
         const secondFilteredRows = await page.$$('table tr');
@@ -178,7 +178,7 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.logs.resetLogsParams();
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the total number of rows to once more equal the original total
         const unfilteredRows = await page.$$('table tr');
@@ -187,19 +187,19 @@ module.exports = () => {
 
         // Close the created at filters now that we are done with them
         await page.click('#authorFilterToggle');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
     });
 
     it('can filter by creation date', async () => {
         // Open the created at filters
         await page.click('#createdAtFilterToggle');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Insert a minimum date into the filter
         await page.focus('#createdFilterFrom');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         await page.type('#createdFilterFrom', '01012020');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the (new) total number of rows to be less than the original number of rows
         const firstFilteredRows = await page.$$('table tr');
@@ -208,9 +208,9 @@ module.exports = () => {
 
         // Insert a maximum date into the filter
         await page.focus('#createdFilterTo');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         await page.type('#createdFilterTo', '01022020');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the table to be empty
         const secondFilteredRows = await page.$$('table tr');
@@ -219,9 +219,9 @@ module.exports = () => {
 
         // Insert a maximum date into the filter that is invalid
         await page.focus('#createdFilterTo');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         await page.type('#createdFilterTo', '01012000');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Do not expect anything to change, as this maximum is below the minimum, therefore the API is not called
         const thirdFilteredRows = await page.$$('table tr');
@@ -233,22 +233,22 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.logs.resetLogsParams();
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Close the title filter now that we are done with it
         await page.click('#createdAtFilterToggle');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
     });
 
     it('can filter by tags', async () => {
         // Open the tag filters
         await page.click('#tagsFilterToggle');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Select the first available filter and wait for the changes to be processed
         const firstCheckboxId = 'tagCheckbox1';
         await page.click(`#${firstCheckboxId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the (new) total number of rows to be less than the original number of rows
         const firstFilteredRows = await page.$$('table tr');
@@ -257,7 +257,7 @@ module.exports = () => {
 
         // Deselect the filter and wait for the changes to process
         await page.click(`#${firstCheckboxId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the total number of rows to equal the original total
         const firstUnfilteredRows = await page.$$('table tr');
@@ -266,9 +266,9 @@ module.exports = () => {
         // Select the first two available filters at once
         const secondCheckboxId = 'tagCheckbox2';
         await page.click(`#${firstCheckboxId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         await page.click(`#${secondCheckboxId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the table to be empty
         const secondFilteredRows = await page.$$('table tr');
@@ -277,7 +277,7 @@ module.exports = () => {
 
         // Set the filter operation to "OR"
         await page.click('#tagFilterOperationRadioButtonOR');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect there now to be more rows than both the previous table and the table with only one filter
         const thirdFilteredRows = await page.$$('table tr');
@@ -298,7 +298,7 @@ module.exports = () => {
 
         // Open the tag filters again
         await page.click('#tagsFilterToggle');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the page to have a button allowing for showing more tags
         const toggleFiltersButton = await page.$(buttonId);
@@ -307,7 +307,7 @@ module.exports = () => {
 
         // Expect the button to show at least one extra tag when clicked
         await page.click(buttonId);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         let extraTagFilter = await page.$(`#tagCheckbox${TAGS_LIMIT + 1}`);
         expect(Boolean(extraTagFilter)).to.be.true;
 
@@ -317,37 +317,37 @@ module.exports = () => {
 
         // Expect the button to remove the extra tag when clicked again
         await page.click(buttonId);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         extraTagFilter = await page.$(`#tagCheckbox${TAGS_LIMIT + 1}`);
         expect(Boolean(extraTagFilter)).to.be.false;
 
         // Close the tag filters now that we are done with them
         await page.click('#tagsFilterToggle');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
     });
 
     it('can sort by columns in ascending and descending manners', async () => {
         // Expect a sorting preview to appear when hovering over a column header
         await page.hover('th#title');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const sortingPreviewIndicator = await page.$('#title-sort-preview');
         expect(Boolean(sortingPreviewIndicator)).to.be.true;
 
         // Sort by log title in an ascending manner
         const titleHeader = await page.$('th#title');
         await titleHeader.evaluate((button) => button.click());
-        await page.waitFor(200);
+        await page.waitForTimeout(200);
 
         // Expect the log titles to be in alphabetical order
         const firstTitles = await getAllDataFields(page, 'title');
         expect(firstTitles).to.deep.equal(firstTitles.sort());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const sortingIndicator = await page.$('#title-sort');
         expect(Boolean(sortingIndicator)).to.be.true;
 
         // Toggle to sort this towards reverse alphabetical order
         await titleHeader.evaluate((button) => button.click());
-        await page.waitFor(200);
+        await page.waitForTimeout(200);
 
         // Expect the log titles to be in reverse alphabetical order
         const secondTitles = await getAllDataFields(page, 'title');
@@ -355,7 +355,7 @@ module.exports = () => {
 
         // Toggle to clear this sorting
         await titleHeader.evaluate((button) => button.click());
-        await page.waitFor(200);
+        await page.waitForTimeout(200);
 
         // Expect the log titles to no longer be sorted in any way
         const thirdTitles = await getAllDataFields(page, 'title');
@@ -365,7 +365,7 @@ module.exports = () => {
         // Sort by log author in ascending manner
         const authorHeader = await page.$('th#author');
         await authorHeader.evaluate((button) => button.click());
-        await page.waitFor(200);
+        await page.waitForTimeout(200);
 
         // Expect the authors to be in alphabetical order
         const firstAuthors = await getAllDataFields(page, 'author');
@@ -374,7 +374,7 @@ module.exports = () => {
         // Sort by creation date in ascending manner
         const createdAtHeader = await page.$('th#createdAt');
         await createdAtHeader.evaluate((button) => button.click());
-        await page.waitFor(200);
+        await page.waitForTimeout(200);
 
         // Expect the log author column to be unsorted
         const secondAuthors = await getAllDataFields(page, 'author');
@@ -425,14 +425,14 @@ module.exports = () => {
 
         // Expect the dropdown options to be visible when it is selected
         await amountSelectorButton.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const amountSelectorDropdown = await page.$(`${amountSelectorId} .dropdown-menu`);
         expect(Boolean(amountSelectorDropdown)).to.be.true;
 
         // Expect the amount of visible logs to reduce when the first option (5) is selected
         const menuItem = await page.$(`${amountSelectorId} .dropdown-menu .menu-item`);
         await menuItem.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         const tableRows = await page.$$('table tr');
         expect(tableRows.length - 1).to.equal(5);
@@ -450,7 +450,7 @@ module.exports = () => {
         const oldFirstRowId = await getFirstRow(table, page);
         const secondPage = await page.$('#page2');
         await secondPage.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         table = await page.$$('tr');
         const newFirstRowId = await getFirstRow(table, page);
         expect(oldFirstRowId).to.not.equal(newFirstRowId);
@@ -458,7 +458,7 @@ module.exports = () => {
         // Expect us to be able to do the same with the page arrows
         const prevPage = await page.$('#pageMoveLeft');
         await prevPage.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const oldFirstPageButton = await page.$('#page1');
         const oldFirstPageButtonClass = await page.evaluate((element) => element.className, oldFirstPageButton);
         expect(oldFirstPageButtonClass).to.include('selected');
@@ -466,7 +466,7 @@ module.exports = () => {
         // The same, but for the other (right) arrow
         const nextPage = await page.$('#pageMoveRight');
         await nextPage.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const newFirstPageButton = await page.$('#page1');
         const newFirstPageButtonClass = await page.evaluate((element) => element.className, newFirstPageButton);
         expect(newFirstPageButtonClass).to.not.include('selected');
@@ -478,7 +478,7 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.logs.setLogsPerPage(1);
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the page five button to now be visible, but no more than that
         const pageFiveButton = await page.$('#page5');
@@ -488,7 +488,7 @@ module.exports = () => {
 
         // Expect the page one button to have fallen away when clicking on page five button
         await page.click('#page5');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const pageOneButton = await page.$('#page1');
         expect(Boolean(pageOneButton)).to.be.false;
 
@@ -502,7 +502,7 @@ module.exports = () => {
     it('can navigate to the log creation page', async () => {
         // Click on the button to start creating a new log
         await page.click('#create');
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Expect the page to be the log creation page at this point
         const redirectedUrl = await page.url();
@@ -512,7 +512,7 @@ module.exports = () => {
     it('notifies if table loading returned an error', async () => {
         // Go back to the home page
         await page.click('#log-overview');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         /*
          * As an example, override the amount of logs visible per page manually
@@ -522,7 +522,7 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.logs.setLogsPerPage(200);
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be a fitting error message
         const error = await page.$('.alert-danger');
@@ -535,20 +535,20 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.logs.setLogsPerPage(10);
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
     });
 
     it('can navigate to a log detail page', async () => {
         // Go back to the home page
         await page.click('#log-overview');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         parsedFirstRowId = parseInt(firstRowId.slice('row'.length, firstRowId.length), 10);
 
         // We expect the entry page to have the same id as the id from the log overview
         const row = await page.$(`tr#${firstRowId}`);
         await row.evaluate((row) => row.click());
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         const redirectedUrl = await page.url();
         expect(redirectedUrl).to.equal(`${url}/?page=log-detail&id=${parsedFirstRowId}`);
@@ -558,30 +558,30 @@ module.exports = () => {
         // Go back to the home page
         const homeButton = await page.$('#log-overview');
         await homeButton.evaluate((button) => button.click());
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Override the amount of logs visible per page manually
         await page.evaluate(() => {
             // eslint-disable-next-line no-undef
             model.logs.setLogsPerPage(1);
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Go to the second page of "logs"
         const secondPageButton = await page.$('#page2');
         await secondPageButton.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Navigate to a log detail page
         table = await page.$$('tr');
         firstRowId = await getFirstRow(table, page);
         const row = await page.$(`tr#${firstRowId}`);
         await row.evaluate((row) => row.click());
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Go back to the home page again
         await page.goBack();
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the pagination to still be on page two
         const firstPageButton = await page.$('#page1');

--- a/test/public/runs/detail.test.js
+++ b/test/public/runs/detail.test.js
@@ -68,7 +68,7 @@ module.exports = () => {
 
     it('run detail loads correctly', async () => {
         await page.goto(`${url}/?page=run-detail&id=1`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         const postExists = await page.$('h2');
         expect(Boolean(postExists)).to.be.true;
@@ -79,21 +79,21 @@ module.exports = () => {
 
     it('can navigate to the log panel', async () => {
         await page.click('#logs-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=run-detail&id=1&panel=logs`)).to.be.true;
     });
 
     it('can navigate to the main panel', async () => {
         await page.click('#main-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=run-detail&id=1&panel=main`)).to.be.true;
     });
 
     it('can navigate to the log panel', async () => {
         await page.click('#logs-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=run-detail&id=1&panel=logs`)).to.be.true;
     });
@@ -104,7 +104,7 @@ module.exports = () => {
 
         // We expect the entry page to have the same id as the id from the run overview
         await page.click(`#${firstRowId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=log-detail&id=1`)).to.be.true;
     });
@@ -112,7 +112,7 @@ module.exports = () => {
     it('notifies if a specified run id is invalid', async () => {
         // Navigate to a run detail view with an id that cannot exist
         await page.goto(`${url}/?page=run-detail&id=abc`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be an error message
         const error = await page.$('.alert');
@@ -124,7 +124,7 @@ module.exports = () => {
     it('notifies if a specified run id is not found', async () => {
         // Navigate to a run detail view with an id that cannot exist
         await page.goto(`${url}/?page=run-detail&id=999`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be an error message
         const error = await page.$('.alert');
@@ -141,7 +141,7 @@ module.exports = () => {
 
         // We expect the button to return the user to the overview page when pressed
         await returnButton.click();
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=run-overview`)).to.be.true;
     });

--- a/test/public/runs/detail.test.js
+++ b/test/public/runs/detail.test.js
@@ -67,8 +67,7 @@ module.exports = () => {
     });
 
     it('run detail loads correctly', async () => {
-        await page.goto(`${url}/?page=run-detail&id=1`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=run-detail&id=1`, { waitUntil: 'networkidle0' });
 
         const postExists = await page.$('h2');
         expect(Boolean(postExists)).to.be.true;
@@ -111,8 +110,7 @@ module.exports = () => {
 
     it('notifies if a specified run id is invalid', async () => {
         // Navigate to a run detail view with an id that cannot exist
-        await page.goto(`${url}/?page=run-detail&id=abc`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=run-detail&id=abc`, { waitUntil: 'networkidle0' });
 
         // We expect there to be an error message
         const error = await page.$('.alert');
@@ -123,8 +121,7 @@ module.exports = () => {
 
     it('notifies if a specified run id is not found', async () => {
         // Navigate to a run detail view with an id that cannot exist
-        await page.goto(`${url}/?page=run-detail&id=999`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=run-detail&id=999`, { waitUntil: 'networkidle0' });
 
         // We expect there to be an error message
         const error = await page.$('.alert');

--- a/test/public/runs/overview.test.js
+++ b/test/public/runs/overview.test.js
@@ -70,7 +70,7 @@ module.exports = () => {
 
     it('loads the page successfully', async () => {
         const response = await page.goto(`${url}?page=run-overview`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect the page to return the correct status code, making sure the server is running properly
         expect(response.status()).to.equal(200);
@@ -132,14 +132,14 @@ module.exports = () => {
 
         // Expect the dropdown options to be visible when it is selected
         await amountSelectorButton.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const amountSelectorDropdown = await page.$(`${amountSelectorId} .dropdown-menu`);
         expect(Boolean(amountSelectorDropdown)).to.be.true;
 
         // Expect the amount of visible runs to reduce when the first option (5) is selected
         const menuItem = await page.$(`${amountSelectorId} .dropdown-menu .menu-item`);
         await menuItem.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         const tableRows = await page.$$('table tr');
         expect(tableRows.length - 1).to.equal(5);
@@ -157,7 +157,7 @@ module.exports = () => {
         const oldFirstRowId = await getFirstRow(table, page);
         const secondPage = await page.$('#page2');
         await secondPage.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         table = await page.$$('tr');
         const newFirstRowId = await getFirstRow(table, page);
         expect(oldFirstRowId).to.not.equal(newFirstRowId);
@@ -165,7 +165,7 @@ module.exports = () => {
         // Expect us to be able to do the same with the page arrows
         const prevPage = await page.$('#pageMoveLeft');
         await prevPage.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const oldFirstPageButton = await page.$('#page1');
         const oldFirstPageButtonClass = await page.evaluate((element) => element.className, oldFirstPageButton);
         expect(oldFirstPageButtonClass).to.include('selected');
@@ -173,7 +173,7 @@ module.exports = () => {
         // The same, but for the other (right) arrow
         const nextPage = await page.$('#pageMoveRight');
         await nextPage.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const newFirstPageButton = await page.$('#page1');
         const newFirstPageButtonClass = await page.evaluate((element) => element.className, newFirstPageButton);
         expect(newFirstPageButtonClass).to.not.include('selected');
@@ -185,7 +185,7 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.runs.setRunsPerPage(1);
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // Expect the page five button to now be visible, but no more than that
         const pageFiveButton = await page.$('#page5');
@@ -195,7 +195,7 @@ module.exports = () => {
 
         // Expect the page one button to have fallen away when clicking on page five button
         await page.click('#page5');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const pageOneButton = await page.$('#page1');
         expect(Boolean(pageOneButton)).to.be.false;
     });
@@ -209,7 +209,7 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.runs.setRunsPerPage(200);
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be a fitting error message
         const error = await page.$('.alert-danger');
@@ -222,7 +222,7 @@ module.exports = () => {
             // eslint-disable-next-line no-undef
             model.runs.setRunsPerPage(10);
         });
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
     });
 
     it('can navigate to a run detail page', async () => {
@@ -232,7 +232,7 @@ module.exports = () => {
 
         // We expect the entry page to have the same id as the id from the run overview
         await page.click(`#${firstRowId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=run-detail&id=${parsedFirstRowId}`)).to.be.true;
     });

--- a/test/public/runs/overview.test.js
+++ b/test/public/runs/overview.test.js
@@ -69,8 +69,7 @@ module.exports = () => {
     });
 
     it('loads the page successfully', async () => {
-        const response = await page.goto(`${url}?page=run-overview`);
-        await page.waitForTimeout(100);
+        const response = await page.goto(`${url}?page=run-overview`, { waitUntil: 'networkidle0' });
 
         // We expect the page to return the correct status code, making sure the server is running properly
         expect(response.status()).to.equal(200);

--- a/test/public/subsystems/detail.test.js
+++ b/test/public/subsystems/detail.test.js
@@ -67,8 +67,7 @@ module.exports = () => {
     });
 
     it('subsystem detail loads correctly', async () => {
-        await page.goto(`${url}/?page=subsystem-detail&id=1`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=subsystem-detail&id=1`, { waitUntil: 'networkidle0' });
 
         const postExists = await page.$('h2');
         expect(Boolean(postExists)).to.be.true;
@@ -111,8 +110,7 @@ module.exports = () => {
 
     it('notifies if a specified subsystem id is invalid', async () => {
         // Navigate to a subsystem detail view with an id that cannot exist
-        await page.goto(`${url}/?page=subsystem-detail&id=abc`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=subsystem-detail&id=abc`, { waitUntil: 'networkidle0' });
 
         // We expect there to be an error message
         const error = await page.$('.alert');
@@ -123,8 +121,7 @@ module.exports = () => {
 
     it('notifies if a specified subsystem id is not found', async () => {
         // Navigate to a subsystem detail view with an id that cannot exist
-        await page.goto(`${url}/?page=subsystem-detail&id=999`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=subsystem-detail&id=999`, { waitUntil: 'networkidle0' });
 
         // We expect there to be an error message
         const error = await page.$('.alert');

--- a/test/public/subsystems/detail.test.js
+++ b/test/public/subsystems/detail.test.js
@@ -68,7 +68,7 @@ module.exports = () => {
 
     it('subsystem detail loads correctly', async () => {
         await page.goto(`${url}/?page=subsystem-detail&id=1`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         const postExists = await page.$('h2');
         expect(Boolean(postExists)).to.be.true;
@@ -79,21 +79,21 @@ module.exports = () => {
 
     it('can navigate to the log panel', async () => {
         await page.click('#logs-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=subsystem-detail&id=1&panel=logs`)).to.be.true;
     });
 
     it('can navigate to the main panel', async () => {
         await page.click('#main-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=subsystem-detail&id=1&panel=main`)).to.be.true;
     });
 
     it('can navigate to the log panel', async () => {
         await page.click('#logs-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=subsystem-detail&id=1&panel=logs`)).to.be.true;
     });
@@ -104,7 +104,7 @@ module.exports = () => {
 
         // We expect the entry page to have the same id as the id from the subsystem overview
         await page.click(`#${firstRowId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=log-detail&id=3`)).to.be.true;
     });
@@ -112,7 +112,7 @@ module.exports = () => {
     it('notifies if a specified subsystem id is invalid', async () => {
         // Navigate to a subsystem detail view with an id that cannot exist
         await page.goto(`${url}/?page=subsystem-detail&id=abc`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be an error message
         const error = await page.$('.alert');
@@ -124,7 +124,7 @@ module.exports = () => {
     it('notifies if a specified subsystem id is not found', async () => {
         // Navigate to a subsystem detail view with an id that cannot exist
         await page.goto(`${url}/?page=subsystem-detail&id=999`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be an error message
         const error = await page.$('.alert');

--- a/test/public/subsystems/overview.test.js
+++ b/test/public/subsystems/overview.test.js
@@ -69,7 +69,7 @@ module.exports = () => {
 
     it('loads the page successfully', async () => {
         const response = await page.goto(`${url}?page=subsystem-overview`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect the page to return the correct status code, making sure the server is running properly
         expect(response.status()).to.equal(200);
@@ -86,7 +86,7 @@ module.exports = () => {
 
         // We expect the entry page to have the same id as the id from the subsystem overview
         await page.click(`#${firstRowId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=subsystem-detail&id=${parsedFirstRowId}`)).to.be.true;
     });

--- a/test/public/subsystems/overview.test.js
+++ b/test/public/subsystems/overview.test.js
@@ -68,8 +68,7 @@ module.exports = () => {
     });
 
     it('loads the page successfully', async () => {
-        const response = await page.goto(`${url}?page=subsystem-overview`);
-        await page.waitForTimeout(100);
+        const response = await page.goto(`${url}?page=subsystem-overview`, { waitUntil: 'networkidle0' });
 
         // We expect the page to return the correct status code, making sure the server is running properly
         expect(response.status()).to.equal(200);

--- a/test/public/tags/create.test.js
+++ b/test/public/tags/create.test.js
@@ -82,21 +82,19 @@ module.exports = () => {
     it('shows an error message if tag creation failed', async () => {
         const text = 'EXAMPLE';
 
-        // Return to the tag creation page
-        const buttonCreate = await page.$('button#create');
-        await buttonCreate.evaluate((button) => button.click());
-        await page.waitForTimeout(250);
+        // Go to the tag creation page
+        await page.click('button#create');
 
         // Enter the duplicate text value
+        await page.waitForSelector('#text');
         await page.type('#text', text);
 
-        // Create the new log
-        const buttonSend = await page.$('button#send');
-        await buttonSend.evaluate((button) => button.click());
-        await page.waitForTimeout(500);
+        // Create the new tag
+        await page.click('button#send');
 
         // Because this tag already exists, we expect an error message to appear
-        const errorAlert = await page.$('.alert');
-        expect(Boolean(errorAlert)).to.be.true;
+        await page.waitForSelector('.alert');
+        const errorMessage = await page.$eval('.alert', (element) => element.innerText);
+        expect(errorMessage).to.equal('Conflict: The provided entity already exists');
     });
 };

--- a/test/public/tags/create.test.js
+++ b/test/public/tags/create.test.js
@@ -48,7 +48,7 @@ module.exports = () => {
     it('can create a tag', async () => {
         const text = 'EXAMPLE';
         await page.goto(`${url}/?page=tag-create`);
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Enter the text value
         await page.type('#text', text);
@@ -56,14 +56,14 @@ module.exports = () => {
         // Create the new log
         const buttonSend = await page.$('button#send');
         await buttonSend.evaluate((button) => button.click());
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Return the page to the tag overview
         const buttonOverviews = await page.$('#overviews');
         await buttonOverviews.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         await page.click('#tag-overview');
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Ensure you are at the overview page again
         const redirectedUrl = await page.url();
@@ -71,7 +71,7 @@ module.exports = () => {
 
         // Get the last post and verify the title of the log we posted
         const table = await page.$$('tr');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         const lastRow = await table[table.length - 1];
         const lastRowId = await page.evaluate((element) => element.id, lastRow);
@@ -86,7 +86,7 @@ module.exports = () => {
         // Return to the tag creation page
         const buttonCreate = await page.$('button#create');
         await buttonCreate.evaluate((button) => button.click());
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Enter the duplicate text value
         await page.type('#text', text);
@@ -94,7 +94,7 @@ module.exports = () => {
         // Create the new log
         const buttonSend = await page.$('button#send');
         await buttonSend.evaluate((button) => button.click());
-        await page.waitFor(500);
+        await page.waitForTimeout(500);
 
         // Because this tag already exists, we expect an error message to appear
         const errorAlert = await page.$('.alert');

--- a/test/public/tags/create.test.js
+++ b/test/public/tags/create.test.js
@@ -50,32 +50,25 @@ module.exports = () => {
         await page.goto(`${url}/?page=tag-create`, { waitUntil: 'networkidle0' });
 
         // Enter the text value
+        await page.waitForSelector('#text');
         await page.type('#text', text);
 
-        // Create the new log
-        const buttonSend = await page.$('button#send');
-        await buttonSend.evaluate((button) => button.click());
-        await page.waitForTimeout(250);
+        // Create the new tag
+        await page.click('button#send');
+
+        // Verify the title of the page
+        await page.waitForSelector('.mv2');
+        const tagTitle = await page.$eval('.mv2', (element) => element.innerText);
+        expect(tagTitle).to.equal(`Tag: ${text}`);
 
         // Return the page to the tag overview
-        const buttonOverviews = await page.$('#overviews');
-        await buttonOverviews.evaluate((button) => button.click());
-        await page.waitForTimeout(100);
-        await page.click('#tag-overview');
-        await page.waitForTimeout(250);
-
-        // Ensure you are at the overview page again
-        const redirectedUrl = await page.url();
-        expect(redirectedUrl).to.equal(`${url}/?page=tag-overview`);
+        await page.goto(`${url}/?page=tag-overview`, { waitUntil: 'networkidle0' });
 
         // Get the last post and verify the title of the log we posted
-        const table = await page.$$('tr');
-        await page.waitForTimeout(100);
-
+        const table = await page.$$('.table > tbody > tr');
         const lastRow = await table[table.length - 1];
         const lastRowId = await page.evaluate((element) => element.id, lastRow);
-        const lastRowText = await page.$(`#${lastRowId}-text`);
-        const lastRowInnerText = await page.evaluate((element) => element.innerText, lastRowText);
+        const lastRowInnerText = await page.$eval(`#${lastRowId}-text`, (element) => element.innerText);
         expect(lastRowInnerText).to.equal(text);
     });
 

--- a/test/public/tags/create.test.js
+++ b/test/public/tags/create.test.js
@@ -47,8 +47,7 @@ module.exports = () => {
 
     it('can create a tag', async () => {
         const text = 'EXAMPLE';
-        await page.goto(`${url}/?page=tag-create`);
-        await page.waitForTimeout(250);
+        await page.goto(`${url}/?page=tag-create`, { waitUntil: 'networkidle0' });
 
         // Enter the text value
         await page.type('#text', text);

--- a/test/public/tags/detail.test.js
+++ b/test/public/tags/detail.test.js
@@ -65,7 +65,7 @@ module.exports = () => {
 
     it('tag detail loads correctly', async () => {
         await page.goto(`${url}/?page=tag-detail&id=1`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         const postExists = await page.$('h2');
         expect(Boolean(postExists)).to.be.true;
@@ -76,21 +76,21 @@ module.exports = () => {
 
     it('can navigate to the log panel', async () => {
         await page.click('#logs-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=tag-detail&id=1&panel=logs`)).to.be.true;
     });
 
     it('can navigate to the main panel', async () => {
         await page.click('#main-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=tag-detail&id=1&panel=main`)).to.be.true;
     });
 
     it('can navigate to the log panel', async () => {
         await page.click('#logs-tab');
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=tag-detail&id=1&panel=logs`)).to.be.true;
     });
@@ -102,7 +102,7 @@ module.exports = () => {
 
         // We expect the entry page to have the same id as the id from the tag overview
         await page.click(`#${firstRowId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=log-detail&id=${parsedFirstRowId}`)).to.be.true;
     });
@@ -110,7 +110,7 @@ module.exports = () => {
     it('notifies if a specified tag id is invalid', async () => {
         // Navigate to a tag detail view with an id that cannot exist
         await page.goto(`${url}/?page=tag-detail&id=abc`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be an error message
         const error = await page.$('.alert');
@@ -122,7 +122,7 @@ module.exports = () => {
     it('notifies if a specified tag id is not found', async () => {
         // Navigate to a tag detail view with an id that cannot exist
         await page.goto(`${url}/?page=tag-detail&id=999`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect there to be an error message
         const error = await page.$('.alert');

--- a/test/public/tags/detail.test.js
+++ b/test/public/tags/detail.test.js
@@ -64,8 +64,7 @@ module.exports = () => {
     });
 
     it('tag detail loads correctly', async () => {
-        await page.goto(`${url}/?page=tag-detail&id=1`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=tag-detail&id=1`, { waitUntil: 'networkidle0' });
 
         const postExists = await page.$('h2');
         expect(Boolean(postExists)).to.be.true;
@@ -109,8 +108,7 @@ module.exports = () => {
 
     it('notifies if a specified tag id is invalid', async () => {
         // Navigate to a tag detail view with an id that cannot exist
-        await page.goto(`${url}/?page=tag-detail&id=abc`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=tag-detail&id=abc`, { waitUntil: 'networkidle0' });
 
         // We expect there to be an error message
         const error = await page.$('.alert');
@@ -121,8 +119,7 @@ module.exports = () => {
 
     it('notifies if a specified tag id is not found', async () => {
         // Navigate to a tag detail view with an id that cannot exist
-        await page.goto(`${url}/?page=tag-detail&id=999`);
-        await page.waitForTimeout(100);
+        await page.goto(`${url}/?page=tag-detail&id=999`, { waitUntil: 'networkidle0' });
 
         // We expect there to be an error message
         const error = await page.$('.alert');

--- a/test/public/tags/overview.test.js
+++ b/test/public/tags/overview.test.js
@@ -66,7 +66,7 @@ module.exports = () => {
 
     it('loads the page successfully', async () => {
         const response = await page.goto(`${url}?page=tag-overview`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
 
         // We expect the page to return the correct status code, making sure the server is running properly
         expect(response.status()).to.equal(200);
@@ -83,7 +83,7 @@ module.exports = () => {
 
         // We expect the entry page to have the same id as the id from the tag overview
         await page.click(`#${firstRowId}`);
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=tag-detail&id=${parsedFirstRowId}`)).to.be.true;
     });
@@ -92,13 +92,13 @@ module.exports = () => {
         // Return the page to the tag overview
         const buttonOverviews = await page.$('#overviews');
         await buttonOverviews.evaluate((button) => button.click());
-        await page.waitFor(100);
+        await page.waitForTimeout(100);
         await page.click('#tag-overview');
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Click on the button to start creating a new tag
         await page.click('#create');
-        await page.waitFor(250);
+        await page.waitForTimeout(250);
 
         // Expect the page to be the tag creation page at this point
         const redirectedUrl = await page.url();

--- a/test/public/tags/overview.test.js
+++ b/test/public/tags/overview.test.js
@@ -65,8 +65,7 @@ module.exports = () => {
     });
 
     it('loads the page successfully', async () => {
-        const response = await page.goto(`${url}?page=tag-overview`);
-        await page.waitForTimeout(100);
+        const response = await page.goto(`${url}?page=tag-overview`, { waitUntil: 'networkidle0' });
 
         // We expect the page to return the correct status code, making sure the server is running properly
         expect(response.status()).to.equal(200);


### PR DESCRIPTION
In regards to the usage of page.waitForTimeout(milliseconds) see the API description of page.waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])
> https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagewaitforselectororfunctionortimeout-options-args

In regards to the load option in the page.goto(url[, options]) calls, 
> **networkidle0** - consider navigation to be finished when there are no more than 0 network connections for at least 500 ms.