### PR TITLE
JWT Default configuration 1 year

### DIFF
--- a/lib/config/jwt.js
+++ b/lib/config/jwt.js
@@ -13,9 +13,9 @@
 
 // Default configuration
 let secret = null;
-let expiration = '1d';
+let expiration = '1y';
 let issuer = 'o2-ui';
-let maxAge = '7d';
+let maxAge = '1y';
 
 if (process.env.JWT_SECRET) {
     secret = process.env.JWT_SECRET;


### PR DESCRIPTION
`expiration` and `maxAge`  have been set to `1y` 