### PR TITLE
Add GH workflow to create bundled TARballs on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_content_type: application/tar+gzip
-        asset_path: .${{ steps.tgz.outputs.tgz_name }}
+        asset_path: ./${{ steps.tgz.outputs.tgz_name }}
         asset_name: ${{ steps.tgz.outputs.tgz_name }}
     - name: Set output
       run: echo ::set-output name=asset_url::${{ steps.upload.browser_download_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - name: Install production deps
       run: npm install --only=production
+    - name: Remove Go and C++ files
+      run: rm -rf cpp-api-client go-api-client
     - name: Create package tarball
       run:  echo ::set-output name=tgz_name::$(npm pack)
       id: tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+on:
+  release:
+    types: [created]
+jobs:
+  upload-asset:
+    runs-on: ubuntu-latest
+    outputs:
+      ASSET_URL: ${{ steps.upload.outputs.asset_url }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Install production deps
+      run: npm install --only=production
+    - name: Create package tarball
+      run:  echo ::set-output name=tgz_name::$(npm pack)
+      id: tgz
+    - name: Upload tarball to release assets
+      uses: actions/upload-release-asset@v1
+      id: upload
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_content_type: application/tar+gzip
+        asset_path: .${{ steps.tgz.outputs.tgz_name }}
+        asset_name: ${{ steps.tgz.outputs.tgz_name }}
+    - name: Set output
+      run: echo ::set-output name=asset_url::${{ steps.upload.browser_download_url }}


### PR DESCRIPTION
This is required to install Bookkeeping without connection to npm registry.

After creating a release (tag is not enough) this workflow will automatically upload TARBall to assets with all necessary deps.