### PR TITLE
[O2-2512] Make /api/runs route public

### DIFF
--- a/lib/server/routers/runs.router.js
+++ b/lib/server/routers/runs.router.js
@@ -15,7 +15,7 @@ const { RunsController } = require('../controllers');
 
 module.exports = {
     path: '/runs',
-    args: { public: false },
+    args: { public: true },
     children: [
         {
             method: 'get',

--- a/lib/usecases/run/EndRunUseCase.js
+++ b/lib/usecases/run/EndRunUseCase.js
@@ -43,7 +43,7 @@ class EndRunUseCase {
         const { timeO2End, timeTrgEnd, runQuality } = body;
 
         return await TransactionHelper.provide(async () => {
-            body.userId = dto.session.id || null;
+            body.userId = dto?.session?.id || 0;
 
             const queryBuilder = new QueryBuilder().where('runNumber').is(runId);
 

--- a/lib/usecases/run/StartRunUseCase.js
+++ b/lib/usecases/run/StartRunUseCase.js
@@ -41,7 +41,7 @@ class StartRunUseCase {
     async execute(dto) {
         const { body } = dto;
         const run = await TransactionHelper.provide(async () => {
-            body.userId = dto.session.id || null;
+            body.userId = dto?.session?.id || 0;
 
             return RunRepository.insert(RunAdapter.toDatabase(body));
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/bookkeeping",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/bookkeeping",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "author": "CERN",
   "license": "GPL-3.0",
   "scripts": {


### PR DESCRIPTION
Until token management is ready we need to make sure that all subsystem will be able to access `/api/runs` route