### PR TITLE
[O2B-462] - Run Details clears log on tag update

### DIFF
--- a/lib/public/views/Runs/Details/index.js
+++ b/lib/public/views/Runs/Details/index.js
@@ -84,7 +84,7 @@ const runDetails = (model) => {
         return [
             h('.flex-row.w-100', [
                 h('.flex.w-50', [
-                    h('h2.mv2.mh2', { onremove: () => model.runs.clearRun() }, `Run #${data.payload.runNumber}`),
+                    h('h2.mv2.mh2', `Run #${data.payload.runNumber}`),
                     h('.flex-row.mv2', [
                         h('button.btn.btn-primary.w-30.mh2#create', {
                             onclick: () => model.router.go(`/?page=log-create&id=${data.payload.runNumber}`),
@@ -123,7 +123,10 @@ const runDetails = (model) => {
             h('.w-100', [
                 h('ul.nav.nav-tabs', Object.entries(panels).map(([id, { name }]) =>
                     h('li.nav-item', h(`a.nav-link${activePanel === id ? '.active' : ''}`, {
-                        onclick: (e) => activePanel !== id && model.router.handleLinkEvent(e),
+                        onclick: (e) => {
+                            activePanel !== id && model.router.handleLinkEvent(e);
+                            model.runs.switchTab(id);
+                        },
                         href: targetURL(model, 'panel', id),
                         id: `${id}-tab`,
                     }, name)))),

--- a/lib/public/views/Runs/Runs.js
+++ b/lib/public/views/Runs/Runs.js
@@ -542,6 +542,21 @@ export default class Overview extends Observable {
     }
 
     /**
+     * Sets the run data to default and either sets the logs or flps data to not asked based on the active tab.
+     * @param {String} id of the tab
+     * @return {undefined}
+     */
+    switchTab(id) {
+        this.run = RemoteData.NotAsked();
+
+        if (id == 'flps') {
+            this.logsOfRun = RemoteData.NotAsked();
+        } else {
+            this.flpsOfRun = RemoteData.NotAsked();
+        }
+    }
+
+    /**
      * Sets all data related to a run to their defaults.
      * @returns {undefined}
      */


### PR DESCRIPTION
Added a new method that now checks for the switching of tabs to clear out the not required data.
Replaced the onRemove on the whole div to an onclick on the two tabs to switch between them.

Keeping the onRemove and passing a parameter with the current tab would either cause one of the two active tabs to get emptied on the tag update or cause the renderer to endlessly update when switching between flps and logs.