### PR TITLE
[O2B-467] Add Bookkeping GH templates and extend on current workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @graduta

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+Thank you for your pull request!
+
+Please fill up one of the checklist below by changing [ ] to [x].
+Remove checklist and/or items that do not apply.
+-->
+
+#### I have a JIRA ticket
+- [ ] branch and/or PR name(s) include(s) JIRA ID
+- [ ] issue has "Fix version" assigned
+- [ ] issue "Status" is set to "In review"
+- [ ] PR labels are selected
+
+
+#### I DON'T have JIRA ticket
+- [ ] explain what this PR does
+- [ ] if it is a new feature, explain how you plan to use it
+- [ ] tests are added
+- [ ] documentation was updated or added

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,24 +3,49 @@ on:
   release:
     types: [created]
 jobs:
+   deploy-npm-module:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Check released tag matches ALICE O2 naming pattern
+      run: |
+        if ! [[ $GITHUB_REF =~ @aliceo2\/[a-z]+-*[a-z]*@*.* ]]; then
+          echo "TAG: ${GITHUB_REF} does not match expected pattern";
+          exit 1;
+        else
+          echo "TAG is correct"
+        fi
+    - name: Set variables PROJECT and VERSION for what is being released
+      id: set-project
+      run: |
+        VERSION=$( echo "${GITHUB_REF/refs\/tags\/@aliceo2\/}" | cut -f2 -d"@")
+        PROJECT="Bookkeeping"
+        echo "Identified project: $PROJECT with version: $VERSION"
+        echo "PROJECT=$PROJECT" >> $GITHUB_ENV
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_DEPLOY_TOKEN }}
   upload-asset:
     runs-on: ubuntu-latest
+    needs: deploy-npm-module
     outputs:
       ASSET_URL: ${{ steps.upload.outputs.asset_url }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
       with:
-        node-version: '14.x'
+        node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'
-    - name: Install production deps
+    - name: Install production dependencies
       run: npm install --only=production
-    - name: Remove Go and C++ files
-      run: rm -rf cpp-api-client go-api-client
     - name: Create package tarball
       run:  echo ::set-output name=tgz_name::$(npm pack)
       id: tgz
-    - name: Upload tarball to release assets
+    - name: Upload tarball to GH release assets
       uses: actions/upload-release-asset@v1
       id: upload
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [created]
 jobs:
-   deploy-npm-module:
+  deploy-npm-module:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "umzug": "2.3.0"
   },
   "files": [
-    "lib/"
+    "lib/",
+    "docs/"
   ],
   "bundledDependencies": [
     "@aliceo2/web-ui",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@aliceo2/bookkeeping",
   "version": "0.19.0",
-  "author": "CERN",
-  "license": "GPL-3.0",
+  "author": "ALICEO2",
   "scripts": {
     "coverage": "nyc npm test && npm run coverage:report",
     "coverage:report": "nyc report --reporter=html --reporter=json",
@@ -25,6 +24,19 @@
     "sequelize": "6.11.0",
     "umzug": "2.3.0"
   },
+  "files": [
+    "lib/"
+  ],
+  "bundledDependencies": [
+    "@aliceo2/web-ui",
+    "cls-hooked",
+    "deepmerge",
+    "joi",
+    "mariadb",
+    "multer",
+    "sequelize",
+    "umzug"
+  ],
   "devDependencies": {
     "chai": "4.3.4",
     "chai-openapi-response-validator": "0.13.0",


### PR DESCRIPTION
* Adds `CODEOWNERS` file to automatically add reviewers;
* Adds new GH workflow that will automatically release an npm module to NPM registry when a release is created;
* Adds GH pull request template
* Adds `nodejs 16` to `release` and `upload tar` workflows
* Migrate to use `checkout/v2`
* Migrate to use `setup-node/v2`
* Specify `bundledDependencies` when packing as NPM
* Specify `files` to bundle when packing as NPM
