### PR TITLE
[O2B-460] Adding details button to logs/runs tables.

### DIFF
--- a/lib/public/components/Table/rows.js
+++ b/lib/public/components/Table/rows.js
@@ -82,7 +82,7 @@ const rows = (data, keys, model, params, cssClass) => {
 
     return h('tbody', data.map((entry) => {
         const rowId = `row${entry[idKey]}`;
-        return h(`tr#${rowId}.clickable.${cssClass}`, params(entry), Object.entries(keys).reduce((accumulator,
+        return h(`tr#${rowId}${cssClass}`, params(entry), Object.entries(keys).reduce((accumulator,
             [key, value]) => {
             if (value.visible) {
                 accumulator.push(content(key, value, entry[key], rowId, model, entry));

--- a/lib/public/views/About/Overview/index.js
+++ b/lib/public/views/About/Overview/index.js
@@ -32,7 +32,7 @@ const aboutOverview = (model) => {
         port: { name: 'Port', size: 'cell-s', visible: true },
     };
 
-    return h('.flex-row.mv1', [h('.w-100', h('.w-100.flex-column.mh3', [table(data, aboutColumns, model)]))]);
+    return h('.flex-row.mv1', [h('.w-100', h('.w-100.flex-column.mh3', [table(data, aboutColumns, model, (_) => ({}), '')]))]);
 };
 
 export default (model) => [aboutOverview(model)];

--- a/lib/public/views/Home/Overview/index.js
+++ b/lib/public/views/Home/Overview/index.js
@@ -28,23 +28,22 @@ const HomeOverviewScreen = (model) => {
     const runsColumns = activeRunsColumns(model);
 
     logsColumns.title.size = 'cell-f';
-    logsColumns.createdAt.size = 'cell-fm';
+    logsColumns.createdAt.size = 'cell-f';
+    logsColumns.actions.size = 'cell-fm';
 
     return h('', [
         h('.flex-row.w-100', [
             h('.flex-column.w-50', [
                 h('h1', 'Log Entries'),
                 h('.w-90', logs.isSuccess() && h('.w-100.flex-column.mh3', [
-                    table(logs.isSuccess() ? logs.payload : [], logsColumns, model, (entry) => ({
-                        onclick: () => model.router.go(`?page=log-detail&id=${entry.id}`),
+                    table(logs.isSuccess() ? logs.payload : [], logsColumns, model, (_) => ({
                     }), 'home'),
                 ])),
             ]),
             h('.flex-column.w-50', [
                 h('h1', 'Runs'),
                 h('.w-90', runs.isSuccess() && h('.w-100.flex-column.mh3', [
-                    table(runs.isSuccess() ? runs.payload : [], runsColumns, model, (entry) => ({
-                        onclick: () => model.router.go(`?page=run-detail&id=${entry.id}`),
+                    table(runs.isSuccess() ? runs.payload : [], runsColumns, model, (_) => ({
                     }), 'home'),
                 ])),
             ]),

--- a/lib/public/views/Home/Overview/index.js
+++ b/lib/public/views/Home/Overview/index.js
@@ -37,14 +37,14 @@ const HomeOverviewScreen = (model) => {
                 h('h1', 'Log Entries'),
                 h('.w-90', logs.isSuccess() && h('.w-100.flex-column.mh3', [
                     table(logs.isSuccess() ? logs.payload : [], logsColumns, model, (_) => ({
-                    }), 'home'),
+                    }), ''),
                 ])),
             ]),
             h('.flex-column.w-50', [
                 h('h1', 'Runs'),
                 h('.w-90', runs.isSuccess() && h('.w-100.flex-column.mh3', [
                     table(runs.isSuccess() ? runs.payload : [], runsColumns, model, (_) => ({
-                    }), 'home'),
+                    }), ''),
                 ])),
             ]),
         ]),

--- a/lib/public/views/Logs/ActiveColumns/index.js
+++ b/lib/public/views/Logs/ActiveColumns/index.js
@@ -103,6 +103,14 @@ const activeColumns = (model) => ({
         size: 'cell-xs',
         format: (attachments) => iconWithCountContainer(attachments.length, iconPaperclip()),
     },
+    actions: {
+        name: 'Actions',
+        visible: true,
+        sortable: false,
+        size: 'cell-m',
+        format: (_, log) =>
+            h('button.btn.btn-primary', { onclick: () => model.router.go(`?page=log-detail&id=${log.id}`) }, 'More'),
+    },
 });
 
 /**
@@ -134,6 +142,14 @@ export const activeHomeOverviewColumns = (model) => ({
         format: (date) =>
             date ? new Date(date).toLocaleString('en-GB', { timeStyle: 'medium', dateStyle: 'medium' }) : '-',
         filter: createdFilter(model),
+    },
+    actions: {
+        name: 'Actions',
+        visible: true,
+        sortable: false,
+        size: 'cell-s',
+        format: (_, log) =>
+            h('button.btn.btn-primary', { onclick: () => model.router.go(`?page=log-detail&id=${log.id}`) }, 'More'),
     },
 });
 

--- a/lib/public/views/Logs/ActiveColumns/index.js
+++ b/lib/public/views/Logs/ActiveColumns/index.js
@@ -109,7 +109,8 @@ const activeColumns = (model) => ({
         sortable: false,
         size: 'cell-m',
         format: (_, log) =>
-            h('button.btn.btn-primary', { onclick: () => model.router.go(`?page=log-detail&id=${log.id}`) }, 'More'),
+            h(`button#btn${log.id}.btn.btn-primary.clickable`, {
+                onclick: () => model.router.go(`?page=log-detail&id=${log.id}`) }, 'More'),
     },
 });
 
@@ -149,7 +150,8 @@ export const activeHomeOverviewColumns = (model) => ({
         sortable: false,
         size: 'cell-s',
         format: (_, log) =>
-            h('button.btn.btn-primary', { onclick: () => model.router.go(`?page=log-detail&id=${log.id}`) }, 'More'),
+            h(`button#btn${log.id}.btn.btn-primary.clickable`, {
+                onclick: () => model.router.go(`?page=log-detail&id=${log.id}`) }, 'More'),
     },
 });
 

--- a/lib/public/views/Logs/Overview/index.js
+++ b/lib/public/views/Logs/Overview/index.js
@@ -86,9 +86,7 @@ const logOverviewScreen = (model) => {
         ]),
         h('.flex-row.mv1', [
             h('.w-100', h('.w-100.flex-column.mh3', [
-                table(payload, logsColumns, model, (entry) => ({
-                    onclick: () => model.router.go(`?page=log-detail&id=${entry.id}`),
-                })),
+                table(payload, logsColumns, model),
                 h('.flex-row.justify-between.mv3', [
                     h('.w-15', amountSelector(() =>
                         model.logs.toggleLogsDropdownVisible(), (amount) => model.logs

--- a/lib/public/views/Logs/Overview/index.js
+++ b/lib/public/views/Logs/Overview/index.js
@@ -86,7 +86,7 @@ const logOverviewScreen = (model) => {
         ]),
         h('.flex-row.mv1', [
             h('.w-100', h('.w-100.flex-column.mh3', [
-                table(payload, logsColumns, model),
+                table(payload, logsColumns, model, (_) => ({}), ''),
                 h('.flex-row.justify-between.mv3', [
                     h('.w-15', amountSelector(() =>
                         model.logs.toggleLogsDropdownVisible(), (amount) => model.logs

--- a/lib/public/views/Runs/ActiveColumns/index.js
+++ b/lib/public/views/Runs/ActiveColumns/index.js
@@ -11,6 +11,7 @@
  * or submit itself to any jurisdiction.
  */
 
+import { h } from '/js/src/index.js';
 import runNumberFilter from '../../../components/Filters/RunsFilter/runNumber.js';
 import tagsFilter from '../../../components/Filters/RunsFilter/tags.js';
 import o2startFilter from '../../../components/Filters/RunsFilter/o2start.js';
@@ -158,13 +159,22 @@ const activeColumns = (model) => ({
         format: (detectors) => `${detectors}`,
         filter: detectorsFilter(model),
     },
+    actions: {
+        name: 'Actions',
+        visible: true,
+        sortable: false,
+        size: 'cell-m',
+        format: (_, run) =>
+            h('button.btn.btn-primary', { onclick: () => model.router.go(`?page=run-detail&id=${run.id}`) }, 'More'),
+    },
 });
 
 /**
  * Method to retrieve the list of active home overview columns for a generic table component
+ * @param {Object} model The global model object
  * @return {Object} A collection of columns with parameters for the Run table
  */
-export const activeHomeOverviewColumns = () => ({
+export const activeHomeOverviewColumns = (model) => ({
     runNumber: {
         name: 'Run',
         visible: true,
@@ -183,6 +193,14 @@ export const activeHomeOverviewColumns = () => ({
         size: 'cell-l',
         format: (date) =>
             date ? new Date(date).toLocaleString('en-GB', { timeStyle: 'medium', dateStyle: 'medium' }) : '-',
+    },
+    actions: {
+        name: 'Actions',
+        visible: true,
+        sortable: false,
+        size: 'cell-s',
+        format: (_, run) =>
+            h('button.btn.btn-primary', { onclick: () => model.router.go(`?page=run-detail&id=${run.id}`) }, 'More'),
     },
 });
 

--- a/lib/public/views/Runs/ActiveColumns/index.js
+++ b/lib/public/views/Runs/ActiveColumns/index.js
@@ -165,7 +165,8 @@ const activeColumns = (model) => ({
         sortable: false,
         size: 'cell-m',
         format: (_, run) =>
-            h('button.btn.btn-primary', { onclick: () => model.router.go(`?page=run-detail&id=${run.id}`) }, 'More'),
+            h(`button#btn${run.id}.btn.btn-primary.clickable`, {
+                onclick: () => model.router.go(`?page=run-detail&id=${run.id}`) }, 'More'),
     },
 });
 
@@ -200,7 +201,8 @@ export const activeHomeOverviewColumns = (model) => ({
         sortable: false,
         size: 'cell-s',
         format: (_, run) =>
-            h('button.btn.btn-primary', { onclick: () => model.router.go(`?page=run-detail&id=${run.id}`) }, 'More'),
+            h(`button#btn${run.id}.btn.btn-primary.clickable`, {
+                onclick: () => model.router.go(`?page=run-detail&id=${run.id}`) }, 'More'),
     },
 });
 

--- a/lib/public/views/Runs/Overview/index.js
+++ b/lib/public/views/Runs/Overview/index.js
@@ -78,7 +78,7 @@ const runsOverview = (model) => {
         ]),
         h('.flex-row.mv1', [
             h('.w-100', h('.w-100.flex-column.mh3', [
-                table(payload, runsColumns, model),
+                table(payload, runsColumns, model, (_) => ({}), ''),
                 h('.flex-row.justify-between.mv3', [
                     h('.w-15', amountSelector(() =>
                         model.runs.toggleRunsDropdownVisible(), (amount) => model.runs

--- a/lib/public/views/Runs/Overview/index.js
+++ b/lib/public/views/Runs/Overview/index.js
@@ -78,9 +78,7 @@ const runsOverview = (model) => {
         ]),
         h('.flex-row.mv1', [
             h('.w-100', h('.w-100.flex-column.mh3', [
-                table(payload, runsColumns, model, (entry) => ({
-                    onclick: () => model.router.go(`?page=run-detail&id=${entry.id}`),
-                })),
+                table(payload, runsColumns, model),
                 h('.flex-row.justify-between.mv3', [
                     h('.w-15', amountSelector(() =>
                         model.runs.toggleRunsDropdownVisible(), (amount) => model.runs

--- a/test/public/home/overview.test.js
+++ b/test/public/home/overview.test.js
@@ -88,11 +88,11 @@ module.exports = () => {
     });
 
     it('can navigate to a detail page', async () => {
-        const firstRow = await page.$('tr.clickable');
-        const parsedFirstRowId = parseInt(firstRowId.slice('row'.length, firstRowId.length), 10);
+        const firstButton = await page.$('button.clickable');
+        const parsedFirstRowId = parseInt(firstRowId.slice('btn'.length, firstRowId.length), 10);
 
         // We expect the entry page to have the same id as the id from the log overview
-        await firstRow.evaluate((row) => row.click());
+        await firstButton.evaluate((button) => button.click());
         await page.waitForTimeout(500);
 
         const redirectedUrl = await page.url();

--- a/test/public/logs/create.test.js
+++ b/test/public/logs/create.test.js
@@ -246,8 +246,9 @@ module.exports = () => {
         expect(attachmentsCountText).to.equal('2');
 
         // Go to the log detail page
-        const row = await page.$(`tr#${firstRowId}`);
-        await row.evaluate((row) => row.click());
+        const buttonId = parseInt(firstRowId.slice('row'.length, firstRowId.length), 10);
+        const button = await page.$(`button#btn${buttonId}`);
+        await button.evaluate((btn) => btn.click());
         await page.waitForTimeout(500);
         // Click on "Show all" button
         const showAllButton = await page.$('#toggleCollapse');

--- a/test/public/logs/overview.test.js
+++ b/test/public/logs/overview.test.js
@@ -499,12 +499,12 @@ module.exports = () => {
         // Go back to the home page
         await goToPage(page, 'log-overview');
 
-        const firstRow = await page.$('tr.clickable');
-        const firstRowId = await firstRow.evaluate((row) => row.id);
-        parsedFirstRowId = parseInt(firstRowId.slice('row'.length, firstRowId.length), 10);
+        const firstButton = await page.$('button.clickable');
+        const firstRowId = await firstButton.evaluate((btn) => btn.id);
+        parsedFirstRowId = parseInt(firstRowId.slice('btn'.length, firstRowId.length), 10);
 
         // We expect the entry page to have the same id as the id from the log overview
-        await firstRow.evaluate((row) => row.click());
+        await firstButton.evaluate((button) => button.click());
         await page.waitForTimeout(500);
 
         const redirectedUrl = await page.url();
@@ -528,10 +528,10 @@ module.exports = () => {
         await page.waitForTimeout(500);
 
         // Navigate to a log detail page
-        table = await page.$$('tr');
-        firstRowId = await getFirstRow(table, page);
-        const row = await page.$(`tr#${firstRowId}`);
-        await row.evaluate((row) => row.click());
+        const firstRow = await page.$('button.clickable');
+        const firstRowId = await firstRow.evaluate((btn) => btn.id);
+        parsedFirstRowId = parseInt(firstRowId.slice('btn'.length, firstRowId.length), 10);
+        await firstRow.evaluate((button) => button.click());
         await page.waitForTimeout(500);
 
         // Go back to the home page again

--- a/test/public/runs/overview.test.js
+++ b/test/public/runs/overview.test.js
@@ -243,12 +243,12 @@ module.exports = () => {
     });
 
     it('can navigate to a run detail page', async () => {
-        table = await page.$$('tr');
-        firstRowId = await getFirstRow(table, page);
-        const parsedFirstRowId = parseInt(firstRowId.slice('row'.length, firstRowId.length), 10);
+        const firstButton = await page.$('button.clickable');
+        const firstRowId = await firstButton.evaluate((btn) => btn.id);
+        const parsedFirstRowId = parseInt(firstRowId.slice('btn'.length, firstRowId.length), 10);
 
         // We expect the entry page to have the same id as the id from the run overview
-        await pressElement(page, `#${firstRowId}`);
+        await firstButton.evaluate((button) => button.click());
         await page.waitForTimeout(100);
         const redirectedUrl = await page.url();
         expect(String(redirectedUrl).startsWith(`${url}/?page=run-detail&id=${parsedFirstRowId}`)).to.be.true;


### PR DESCRIPTION
Added a button to logs and runs tables to direct the user to a specific log/run, to enable copying of the rows without being redirected. The docker tests were modified accordingly, and tested within browser.

#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [ ] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected