### PR TITLE
[O2B-508] When creating logs double run numbers are filtered in the backend

### DIFF
--- a/lib/usecases/log/CreateLogUseCase.js
+++ b/lib/usecases/log/CreateLogUseCase.js
@@ -63,7 +63,6 @@ class CreateLogUseCase {
 
                 body.rootLogId = parentLog.rootLogId || parentLog.id;
             }
-
             if (tags) {
                 const existingTags = await new GetAllTagsUseCase()
                     .execute({ query: { page: { filter: { ids: tags } } } });
@@ -86,10 +85,11 @@ class CreateLogUseCase {
 
             if (runNumbers) {
                 // Parse comma-separated string to array of numbers
-                const numbers = runNumbers.split(',')
-                    .map((x) => x.trim())
-                    .map((x) => parseInt(x, 10));
-
+                const numbers = [
+                    ...new Set(runNumbers.split(',')
+                        .map((x) => x.trim())
+                        .map((x) => parseInt(x, 10))),
+                ];
                 // Error out if any value is NaN
                 if (numbers.some(Number.isNaN)) {
                     return {

--- a/test/e2e/logs.test.js
+++ b/test/e2e/logs.test.js
@@ -1133,6 +1133,28 @@ module.exports = () => {
                     done();
                 });
         });
+
+        it('should return 201 if a proper body with duplicate run numbers', (done) => {
+            request(server)
+                .post('/api/logs')
+                .field('title', 'Yet another run')
+                .field('text', 'Text of yet another run')
+                .field('runNumbers', '1, 2, 2, 3, 3, 1, 2, 1')
+                .expect(201)
+                .end((err, res) => {
+                    if (err) {
+                        done(err);
+                        return;
+                    }
+                    // Response must satisfy the OpenAPI specification
+                    expect(res).to.satisfyApiSpec;
+
+                    expect(res.body.data.runs).to.deep.include({ id: 1, runNumber: 1 });
+                    expect(res.body.data.runs).to.deep.include({ id: 2, runNumber: 2 });
+                    expect(res.body.data.runs).to.deep.include({ id: 3, runNumber: 3 });
+                    done();
+                });
+        });
     });
 
     describe('GET /api/logs/:logId', () => {

--- a/test/public/home/overview.test.js
+++ b/test/public/home/overview.test.js
@@ -51,7 +51,7 @@ module.exports = () => {
         firstRowId = await getFirstRow(table, page);
 
         // We expect to find a table
-        expect(firstRowId).to.equal('row131');
+        expect(firstRowId).to.equal('row132');
     });
 
     it('shows correct datatypes in respective columns', async () => {

--- a/test/usecases/log/CreateLogUseCase.test.js
+++ b/test/usecases/log/CreateLogUseCase.test.js
@@ -94,4 +94,24 @@ module.exports = () => {
         expect(result.title).to.equal(expectedTitle);
         expect(result.parentLogId).to.equal(expectedParentLogId);
     });
+    it('should create a new Log and filter the title ', async () =>{
+        const expectedResult = [
+            { id: 1, runNumber: 1 },
+            { id: 2, runNumber: 2 },
+            { id: 3, runNumber: 3 },
+        ];
+        const givenRunNumbers = '1,2,2,3,3,1,2,1,2,3';
+
+        createLogDto.body.runNumbers = givenRunNumbers;
+
+        createLogDto.session = {
+            personid: 2,
+            id: 2,
+            name: 'Jan Janssen',
+        };
+
+        const { result } = await new CreateLogUseCase()
+            .execute(createLogDto);
+        expect(result.runs).to.deep.equal(expectedResult);
+    });
 };

--- a/test/usecases/log/CreateLogUseCase.test.js
+++ b/test/usecases/log/CreateLogUseCase.test.js
@@ -94,7 +94,7 @@ module.exports = () => {
         expect(result.title).to.equal(expectedTitle);
         expect(result.parentLogId).to.equal(expectedParentLogId);
     });
-    it('should create a new Log and filter the title ', async () =>{
+    it('should create a new Log with no duplicate run numbers', async () =>{
         const expectedResult = [
             { id: 1, runNumber: 1 },
             { id: 2, runNumber: 2 },


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please fill up one of the checklist below by changing [ ] to [x].
Remove checklist and/or items that do not apply.
-->

#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

There was a bug where when duplicate run numbers are inserted, an internal server error would appear and not save the data. This is now fixed and tested with e2e and use case tests.