### PR TITLE
[O2B-505] Improve listTags API to accept filters for tags retrieval

### DIFF
--- a/lib/database/seeders/20200511151010-tags.js
+++ b/lib/database/seeders/20200511151010-tags.js
@@ -13,24 +13,12 @@
 
 module.exports = {
     up: (queryInterface, _Sequelize) => queryInterface.bulkInsert('tags', [
-        {
-            text: 'FOOD',
-        },
-        {
-            text: 'RUN',
-        },
-        {
-            text: 'MAINTENANCE',
-        },
-        {
-            text: 'GLOBAL',
-        },
-        {
-            text: 'TEST',
-        },
-        {
-            text: 'OTHER',
-        },
+        { text: 'FOOD', email: 'food-group@cern.ch', mattermost: 'food' },
+        { text: 'RUN', email: 'marathon-group@cern.ch', mattermost: 'marathon' },
+        { text: 'MAINTENANCE' },
+        { text: 'GLOBAL' },
+        { text: 'TEST' },
+        { text: 'OTHER', email: 'other-group@cern.ch', mattermost: 'other' },
         { text: 'TEST-TAG-1' },
         { text: 'TEST-TAG-2' },
         { text: 'TEST-TAG-3' },

--- a/lib/domain/dtos/GetAllTagsDto.js
+++ b/lib/domain/dtos/GetAllTagsDto.js
@@ -14,8 +14,16 @@
 const Joi = require('joi');
 const PaginationDto = require('./PaginationDto');
 
+const FilterDto = Joi.object({
+    ids: Joi.string().trim().optional(),
+    texts: Joi.string().trim().optional(),
+    emails: Joi.string().trim().optional(),
+    mattermosts: Joi.string().trim().optional(),
+});
+
 const QueryDto = Joi.object({
     page: PaginationDto,
+    filter: FilterDto,
     token: Joi.string(),
 });
 

--- a/lib/server/controllers/tags.controller.js
+++ b/lib/server/controllers/tags.controller.js
@@ -178,7 +178,7 @@ const listTags = async (request, response, next) => {
     const { query: { page: { limit = 100 } = {} } } = value;
     const totalPages = Math.ceil(count / limit);
 
-    response.status(200).json({
+    response.status(count === 0 ? 204 : 200).json({
         data: tags,
         meta: {
             page: {

--- a/lib/server/routers/tags.router.js
+++ b/lib/server/routers/tags.router.js
@@ -20,6 +20,7 @@ module.exports = {
         {
             method: 'get',
             controller: TagsController.listTags,
+            args: { public: true },
         },
         {
             method: 'post',

--- a/lib/usecases/tag/GetAllTagsUseCase.js
+++ b/lib/usecases/tag/GetAllTagsUseCase.js
@@ -40,8 +40,8 @@ class GetAllTagsUseCase {
     async execute(dto = {}) {
         const queryBuilder = new QueryBuilder();
         const { query = {} } = dto;
-        const { page = {} } = query;
-        const { filter, limit = 100, offset = 0 } = page;
+        const { filter = {}, page = {} } = query;
+        const { limit = 100, offset = 0 } = page;
 
         queryBuilder.limit(limit);
         queryBuilder.offset(offset);
@@ -50,8 +50,24 @@ class GetAllTagsUseCase {
             count,
             rows,
         } = await TransactionHelper.provide(async () => {
-            if (filter && filter.ids) {
-                queryBuilder.where('id').oneOf(...filter.ids);
+            if (filter) {
+                const { ids, texts, emails, mattermosts } = filter;
+                if (ids) {
+                    const idList = ids.split(',').filter((id) => id !== '');
+                    queryBuilder.where('id').oneOf(...idList);
+                }
+                if (texts) {
+                    const textList = texts.split(',').filter((text) => text !== '');
+                    queryBuilder.where('text').oneOf(...textList);
+                }
+                if (emails) {
+                    const emailList = emails.split(',').filter((email) => email !== '');
+                    queryBuilder.where('email').oneOf(...emailList);
+                }
+                if (mattermosts) {
+                    const mattermostList = mattermosts.split(',').filter((mattermost) => mattermost !== '');
+                    queryBuilder.where('mattermost').oneOf(...mattermostList);
+                }
             }
 
             return TagRepository.findAndCountAll(queryBuilder);

--- a/test/e2e/logs.test.js
+++ b/test/e2e/logs.test.js
@@ -1022,14 +1022,14 @@ module.exports = () => {
                         {
                             id: 1,
                             text: 'FOOD',
-                            email: null,
-                            mattermost: null,
+                            email: 'food-group@cern.ch',
+                            mattermost: 'food',
                         },
                         {
                             id: 2,
                             text: 'RUN',
-                            email: null,
-                            mattermost: null,
+                            email: 'marathon-group@cern.ch',
+                            mattermost: 'marathon',
                         },
                     ]);
                     expect(res.body.data.rootLogId).to.equal(1);

--- a/test/usecases/tag/GetAllTagsUseCase.test.js
+++ b/test/usecases/tag/GetAllTagsUseCase.test.js
@@ -12,15 +12,69 @@
  */
 
 const { tag: { GetAllTagsUseCase } } = require('../../../lib/usecases');
+const { dtos: { GetAllTagsDto } } = require('../../../lib/domain');
 const chai = require('chai');
 
 const { expect } = chai;
 
 module.exports = () => {
-    it('should return an array', async () => {
-        const { tags } = await new GetAllTagsUseCase()
-            .execute();
+    let getAllTagsDto;
+
+    beforeEach(async () => {
+        getAllTagsDto = await GetAllTagsDto.validateAsync({});
+    });
+    it('should successfully return an array with tags', async () => {
+        const { tags } = await new GetAllTagsUseCase().execute();
 
         expect(tags).to.be.an('array');
+    });
+    it('should successfully return an array with tags with specified ids', async () => {
+        getAllTagsDto.query = { filter: { ids: '1,2' } };
+        const { tags } = await new GetAllTagsUseCase().execute(getAllTagsDto);
+
+        expect(tags).to.be.an('array');
+        expect(tags).to.have.lengthOf(2);
+        expect(tags[0].id).to.equal(1);
+        expect(tags[0].text).to.equal('FOOD');
+        expect(tags[1].id).to.equal(2);
+        expect(tags[1].text).to.equal('RUN');
+    });
+    it('should successfully return 204 status if no tag was found with specified ids', async () => {
+        getAllTagsDto.query = { filter: { ids: '5002' } };
+        const { tags } = await new GetAllTagsUseCase().execute(getAllTagsDto);
+
+        expect(tags).to.be.an('array');
+        expect(tags).to.have.lengthOf(0);
+    });
+    it('should successfully return an array with tags with specified texts', async () => {
+        getAllTagsDto.query = { filter: { texts: 'FOOD,OTHER' } };
+        const { tags } = await new GetAllTagsUseCase().execute(getAllTagsDto);
+
+        expect(tags).to.be.an('array');
+        expect(tags).to.have.lengthOf(2);
+        expect(tags[0].id).to.equal(1);
+        expect(tags[0].text).to.equal('FOOD');
+        expect(tags[1].id).to.equal(6);
+        expect(tags[1].text).to.equal('OTHER');
+    });
+    it('should successfully return an array with tags with specified emails', async () => {
+        getAllTagsDto.query = { filter: { emails: 'other-group@cern.ch' } };
+        const { tags } = await new GetAllTagsUseCase().execute(getAllTagsDto);
+
+        expect(tags).to.be.an('array');
+        expect(tags).to.have.lengthOf(1);
+        expect(tags[0].id).to.equal(6);
+        expect(tags[0].text).to.equal('OTHER');
+    });
+    it('should successfully return an array with tags with specified mattermosts', async () => {
+        getAllTagsDto.query = { filter: { mattermosts: 'marathon,,food' } };
+        const { tags } = await new GetAllTagsUseCase().execute(getAllTagsDto);
+
+        expect(tags).to.be.an('array');
+        expect(tags).to.have.lengthOf(2);
+        expect(tags[0].id).to.equal(1);
+        expect(tags[0].text).to.equal('FOOD');
+        expect(tags[1].id).to.equal(2);
+        expect(tags[1].text).to.equal('RUN');
     });
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

* Builds on `listTags` to accept filters such as: `ids, texts, emails, mattermosts`
* Adds filter validation
* Returns 204 status if no data is found
* Adds corresponding tests
* Makes GET API `/api/tags/` public