### PR TITLE
Release 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.24.0](https://github.com/AliceO2Group/Bookkeeping/releases/tag/%40aliceo2%2Fbookkeeping%400.24.0) 
+* Notable changes for users:
+  * RUN Filters Improvements:
+    * Allows users to filter by DD, DCS, EPN with ON,OFF or ANY
+  * RUN Exports:
+    * [FIXED] - exporting a list of runs by their runNumber would not retrieve the whole list;
+    * `o2TimeStart`, `o2TimeStop`, `o2TrgStart`, `o2TrgStop` converts timestamps to user friendly date formats;
+  * LOG Creation:
+    * [FIXED] - removes duplicated `runNumbers` when creating a log entry instead of throwing error;
+  * TAGS Page:
+    * Displays new tag information: `email` and `mattermost` groups;
+* Notable changes for developers:
+  * `/api/runs` - listRuns - accepts multiple `runNumbers` for filtering;
+  * `/api/runs` - listRuns - improves filtering for `dcs`, `dd_flp`, `epn`;
+  * `/api/tags` - listTags - accepts multiple `ids`, `texts`, `emails` and/or `mattermosts` as filters;
+
 ## [0.23.0](https://github.com/AliceO2Group/Bookkeeping/releases/tag/%40aliceo2%2Fbookkeeping%400.23.0) 
 * Notable changes for developers:
   * Add as new feature the option to send email and mattermost log creation notification;

--- a/lib/public/views/About/Overview/index.js
+++ b/lib/public/views/About/Overview/index.js
@@ -21,7 +21,7 @@ import table from '../../../components/Table/index.js';
  */
 const aboutOverview = (model) => {
     const data = [
-        { type: 'Bookkeeping', version: '0.23.0', hostname: '-', port: '4000' },
+        { type: 'Bookkeeping', version: '0.24.0', hostname: '-', port: '4000' },
         { type: 'NPM', version: '', hostname: '', port: '' },
     ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/bookkeeping",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/bookkeeping",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "cls-hooked",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/bookkeeping",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "author": "ALICEO2",
   "scripts": {
     "coverage": "nyc npm test && npm run coverage:report",


### PR DESCRIPTION
* Notable changes for users:
  * RUN Filters Improvements:
    * Allows users to filter by DD, DCS, EPN with ON,OFF or ANY
  * RUN Exports:
    * [FIXED] - exporting a list of runs by their runNumber would not retrieve the whole list;
    * `o2TimeStart`, `o2TimeStop`, `o2TrgStart`, `o2TrgStop` converts timestamps to user friendly date formats;
  * LOG Creation:
    * [FIXED] - removes duplicated `runNumbers` when creating a log entry instead of throwing error;
  * TAGS Page:
    * Displays new tag information: `email` and `mattermost` groups;
* Notable changes for developers:
  * `/api/runs` - listRuns - accepts multiple `runNumbers` for filtering;
  * `/api/runs` - listRuns - improves filtering for `dcs`, `dd_flp`, `epn`;
  * `/api/tags` - listTags - accepts multiple `ids`, `texts`, `emails` and/or `mattermosts` as filters;