### PR TITLE
[O2B-507] - Infinite mode in Run Statistics table displays duplicates

### DIFF
--- a/lib/public/components/Pagination/pageSelector.js
+++ b/lib/public/components/Pagination/pageSelector.js
@@ -71,7 +71,7 @@ const pageSelector = (onclick, model) => {
             setTimeout(() => {
                 switchPage(currentScrollPosition, onclick, model.getSelectedPage());
                 ticking = false;
-            }, 100);
+            }, 200);
 
             ticking = true;
         }

--- a/lib/public/views/Logs/Logs.js
+++ b/lib/public/views/Logs/Logs.js
@@ -913,6 +913,7 @@ export default class Overview extends Observable {
     setSelectedPage(page) {
         if (this.selectedPage !== page) {
             this.selectedPage = page;
+            this.notify();
             this.fetchAllLogs();
         }
     }

--- a/lib/public/views/Runs/Runs.js
+++ b/lib/public/views/Runs/Runs.js
@@ -617,8 +617,8 @@ export default class Overview extends Observable {
     setSelectedPage(page) {
         if (this.selectedPage !== page) {
             this.selectedPage = page;
-            this.fetchAllRuns();
             this.notify();
+            this.fetchAllRuns();
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please fill up one of the checklist below by changing [ ] to [x].
Remove checklist and/or items that do not apply.
-->

#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Increased the scroll update delay to give the system more time to set the right value. Notifies before the fetch so the updates are notified to the components faster.