### PR TITLE
[O2B-571] Tag edit mode saves old edit data on page switch

### DIFF
--- a/lib/public/components/TagDetail/index.js
+++ b/lib/public/components/TagDetail/index.js
@@ -36,7 +36,7 @@ const activeFields = (model) => ({
         size: 'cell-l',
         format: (mattermost) => model.tags.isEditModeEnabled ? [
             h('input.form-control.w-60', {
-                placeholder: 'Enter the mattermost channels... ("," seperation)',
+                placeholder: 'Enter the mattermost channels... ("," separation)',
                 value: model.tags.tagChanges['mattermost'],
                 oninput: (e) => {
                     model.tags.tagChanges = { key: 'mattermost', value: e.target.value };
@@ -50,7 +50,7 @@ const activeFields = (model) => ({
         size: 'cell-l',
         format: (email) => model.tags.isEditModeEnabled ? [
             h('input.form-control.w-60', {
-                placeholder: 'Enter email groups... ("," seperation)',
+                placeholder: 'Enter email groups... ("," separation)',
                 value: model.tags.tagChanges['email'],
                 oninput: (e) => {
                     model.tags.tagChanges = { key: 'email', value: e.target.value };

--- a/lib/public/views/Runs/Details/editTagsPanel.js
+++ b/lib/public/views/Runs/Details/editTagsPanel.js
@@ -25,36 +25,32 @@ const editTagsPanel = (model) => {
     const tagsAvailable = allTags.payload != 0;
     const noTagsText = 'No tags defined, please go here to create them.';
     const selectedTags = model.runs.getSelectedTags();
-    return h('', {
-        onremove: () => model.envs.clearEnvs(),
-    }[
-        h('.flex-column.w-60', [
-            h('.w-100.flex-row', {
-                style: 'justify-content: flex-end;',
-            }, h('button.btn.btn-success.w-25#update-tags', {
-                onclick: () => model.runs.updateRunTags(),
-                title: 'This action will overwrite existing tags',
-                disabled: !model.runs.selectedTagsChanged(),
-            }, 'Update Tags')),
-            h('label.form-check-label.f5.w-100.flex-row', {
-                style: 'justify-content: flex-end;',
-                for: 'tags',
-            }, 'Add tags to the run. (CTRL + click for multiple selection).'),
-            h('.w-100.flex-row', {
-                style: 'justify-content: flex-end;',
-            }, h('select#tags-control.form-control.w-50', {
-                multiple: true,
-                size: 10,
-                onchange: ({ target }) => model.runs.setSelectedTags(target.selectedOptions),
-            }, !tagsAvailable ? h('option', {
-                onclick: () => model.router.go('?page=tag-create'),
-            }, h('a#tagCreateLink', noTagsText)) : allTags.isSuccess() ? [
-                ...allTags.payload.map((tag) => h('option', {
-                    value: tag.id,
-                    selected: selectedTags.includes(tag.id),
-                }, tag.text)),
-            ] : h('option', { disabled: true }, 'Loading tags...'))),
-        ])
+    return h('.flex-column.w-60', [
+        h('.w-100.flex-row', {
+            style: 'justify-content: flex-end;',
+        }, h('button.btn.btn-success.w-25#update-tags', {
+            onclick: () => model.runs.updateRunTags(),
+            title: 'This action will overwrite existing tags',
+            disabled: !model.runs.selectedTagsChanged(),
+        }, 'Update Tags')),
+        h('label.form-check-label.f5.w-100.flex-row', {
+            style: 'justify-content: flex-end;',
+            for: 'tags',
+        }, 'Add tags to the run. (CTRL + click for multiple selection).'),
+        h('.w-100.flex-row', {
+            style: 'justify-content: flex-end;',
+        }, h('select#tags-control.form-control.w-50', {
+            multiple: true,
+            size: 10,
+            onchange: ({ target }) => model.runs.setSelectedTags(target.selectedOptions),
+        }, !tagsAvailable ? h('option', {
+            onclick: () => model.router.go('?page=tag-create'),
+        }, h('a#tagCreateLink', noTagsText)) : allTags.isSuccess() ? [
+            ...allTags.payload.map((tag) => h('option', {
+                value: tag.id,
+                selected: selectedTags.includes(tag.id),
+            }, tag.text)),
+        ] : h('option', { disabled: true }, 'Loading tags...'))),
     ]);
 };
 

--- a/lib/public/views/Runs/Details/editTagsPanel.js
+++ b/lib/public/views/Runs/Details/editTagsPanel.js
@@ -25,32 +25,36 @@ const editTagsPanel = (model) => {
     const tagsAvailable = allTags.payload != 0;
     const noTagsText = 'No tags defined, please go here to create them.';
     const selectedTags = model.runs.getSelectedTags();
-    return h('.flex-column.w-60', [
-        h('.w-100.flex-row', {
-            style: 'justify-content: flex-end;',
-        }, h('button.btn.btn-success.w-25#update-tags', {
-            onclick: () => model.runs.updateRunTags(),
-            title: 'This action will overwrite existing tags',
-            disabled: !model.runs.selectedTagsChanged(),
-        }, 'Update Tags')),
-        h('label.form-check-label.f5.w-100.flex-row', {
-            style: 'justify-content: flex-end;',
-            for: 'tags',
-        }, 'Add tags to the run. (CTRL + click for multiple selection).'),
-        h('.w-100.flex-row', {
-            style: 'justify-content: flex-end;',
-        }, h('select#tags-control.form-control.w-50', {
-            multiple: true,
-            size: 10,
-            onchange: ({ target }) => model.runs.setSelectedTags(target.selectedOptions),
-        }, !tagsAvailable ? h('option', {
-            onclick: () => model.router.go('?page=tag-create'),
-        }, h('a#tagCreateLink', noTagsText)) : allTags.isSuccess() ? [
-            ...allTags.payload.map((tag) => h('option', {
-                value: tag.id,
-                selected: selectedTags.includes(tag.id),
-            }, tag.text)),
-        ] : h('option', { disabled: true }, 'Loading tags...'))),
+    return h('', {
+        onremove: () => model.envs.clearEnvs(),
+    }[
+        h('.flex-column.w-60', [
+            h('.w-100.flex-row', {
+                style: 'justify-content: flex-end;',
+            }, h('button.btn.btn-success.w-25#update-tags', {
+                onclick: () => model.runs.updateRunTags(),
+                title: 'This action will overwrite existing tags',
+                disabled: !model.runs.selectedTagsChanged(),
+            }, 'Update Tags')),
+            h('label.form-check-label.f5.w-100.flex-row', {
+                style: 'justify-content: flex-end;',
+                for: 'tags',
+            }, 'Add tags to the run. (CTRL + click for multiple selection).'),
+            h('.w-100.flex-row', {
+                style: 'justify-content: flex-end;',
+            }, h('select#tags-control.form-control.w-50', {
+                multiple: true,
+                size: 10,
+                onchange: ({ target }) => model.runs.setSelectedTags(target.selectedOptions),
+            }, !tagsAvailable ? h('option', {
+                onclick: () => model.router.go('?page=tag-create'),
+            }, h('a#tagCreateLink', noTagsText)) : allTags.isSuccess() ? [
+                ...allTags.payload.map((tag) => h('option', {
+                    value: tag.id,
+                    selected: selectedTags.includes(tag.id),
+                }, tag.text)),
+            ] : h('option', { disabled: true }, 'Loading tags...'))),
+        ])
     ]);
 };
 

--- a/lib/public/views/Tags/Details/index.js
+++ b/lib/public/views/Tags/Details/index.js
@@ -62,7 +62,11 @@ const tagDetails = (model) => {
         return [
             h('.flex-column.w-100', [
                 h('.w-100.flex-row', [
-                    h('h2.mv2.w-40', { onremove: () => model.tags.clearTag() }, `Tag: ${data.payload.text}`),
+                    h('h2.mv2.w-40', { onremove: () => {
+                        model.tags.isEditModeEnabled = false;
+                        model.tags.tagChanges = {};
+                        model.tags.clearTag();
+                    } }, `Tag: ${data.payload.text}`),
                     h('.w-60.flex-row.items-center', {
                         style: 'justify-content: flex-end;',
                     }, model.isAdmin() &&


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please fill up one of the checklist below by changing [ ] to [x].
Remove checklist and/or items that do not apply.
-->

#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Bug and typo is fixed.

Steps to reproduce in the ticket or below:
1) Open the details of one tag.
2) Edit it.
3) Without SAVE or CANCEL, re-open the TAGS overview and select another tag's detail page.
4) Edit it.