### PR TITLE
[O2B-567] Migrate runs.detectors to string type

### DIFF
--- a/lib/database/migrations/20220511102048-update-run-detectors-column.js
+++ b/lib/database/migrations/20220511102048-update-run-detectors-column.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+'use strict';
+/* eslint-disable valid-jsdoc */
+
+module.exports = {
+
+    /**
+     * Update runs.detectors column to a string and move validation on server side
+     * This will allow for multiple detectors to be set as a string separated by comma
+     */
+    up: (queryInterface, Sequelize) => queryInterface.changeColumn('runs', 'detectors', {
+        type: Sequelize.STRING,
+    }),
+
+    /**
+     * Revert above changes
+     */
+    down: (queryInterface, _Sequelize) => queryInterface.changeColumn('runs', 'detectors', {
+        type: _Sequelize.ENUM('CPV', 'EMC', 'FDD', 'FT0', 'FV0', 'HMP', 'ITS', 'MCH', 'MFT', 'MID', 'PHS', 'TOF', 'TPC', 'TRD', 'TST', 'ZDC'),
+    }),
+};

--- a/lib/domain/dtos/StartRunDto.js
+++ b/lib/domain/dtos/StartRunDto.js
@@ -13,6 +13,17 @@
 
 const Joi = require('joi');
 
+const detectorsDto = Joi.extend((joi) => ({
+    base: joi.string(),
+    type: 'detectorList',
+    validate: (value, helpers) => {
+        const validList = ['CPV', 'EMC', 'FDD', 'FT0', 'FV0', 'HMP', 'ITS', 'MCH', 'MFT', 'MID', 'PHS', 'TOF', 'TPC', 'TRD', 'TST', 'ZDC'];
+        const detectorList = value.replace(/^,+|,+$/mg, '').split(',');
+        const isValid = detectorList.every((detector) => validList.includes(detector));
+        return isValid ? { value } : { errors: helpers.error('Provide detector list contains invalid elements') };
+    },
+}));
+
 const BodyDto = Joi.object({
     timeO2Start: Joi.date(),
     timeTrgStart: Joi.date(),
@@ -31,7 +42,7 @@ const BodyDto = Joi.object({
     dcs: Joi.boolean().default(false),
     epn: Joi.boolean().default(false),
     epnTopology: Joi.string(),
-    detectors: Joi.string(),
+    detectors: detectorsDto.detectorList(),
 });
 
 const QueryDto = Joi.object({

--- a/lib/domain/dtos/StartRunDto.js
+++ b/lib/domain/dtos/StartRunDto.js
@@ -35,7 +35,7 @@ const BodyDto = Joi.object({
     nDetectors: Joi.number(),
     nFlps: Joi.number(),
     nEpns: Joi.number(),
-    nSubTimeFrames: Joi.number(),
+    nSubtimeframes: Joi.number(),
     bytesReadOut: Joi.number(),
     runNumber: Joi.number(),
     dd_flp: Joi.boolean().default(false),

--- a/spec/openapi-source.yaml
+++ b/spec/openapi-source.yaml
@@ -1767,6 +1767,7 @@ components:
     RunDetectorsList:
       description: A comma seperated string for the detectors used
       type: string
+      nullable: true
     RunEnvironmentId:
       description: The unique identifier of this entity.
       type: string

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,4 +1,4 @@
-# Generated on Wed, 04 May 2022 12:05:07 GMT
+# Generated on Wed, 11 May 2022 13:45:41 GMT
 
 openapi: 3.0.0
 info:
@@ -1769,6 +1769,7 @@ components:
     RunDetectorsList:
       description: A comma seperated string for the detectors used
       type: string
+      nullable: true
     RunEnvironmentId:
       description: The unique identifier of this entity.
       type: string

--- a/test/e2e/runs.test.js
+++ b/test/e2e/runs.test.js
@@ -397,4 +397,70 @@ module.exports = () => {
                 });
         });
     });
+
+    describe('POST /api/runs', () => {
+        it('should successfully return the stored run entity', (done) => {
+            request(server)
+                .post('/api/runs')
+                .expect(201)
+                .send({
+                    runNumber: 109,
+                    timeO2Start: '2022-03-21 13:00:00',
+                    timeTrgStart: '2022-03-21 13:00:00',
+                    environmentId: '1234567890',
+                    runType: 'technical',
+                    runQuality: 'good',
+                    nDetectors: 3,
+                    nFlps: 10,
+                    nEpns: 10,
+                    dd_flp: true,
+                    dcs: true,
+                    epn: true,
+                    epnTopology: 'normal',
+                    detectors: 'CPV',
+                })
+                .end((err, res) => {
+                    if (err) {
+                        done(err);
+                        return;
+                    }
+                    expect(res.body.data).to.be.an('object');
+                    expect(res.body.data.id).to.equal(109);
+
+                    done();
+                });
+        });
+        it('should return an error due to invalid detectors list', (done) => {
+            request(server)
+                .post('/api/runs')
+                .expect(400)
+                .send({
+                    runNumber: 109,
+                    timeO2Start: '2022-03-21 13:00:00',
+                    timeTrgStart: '2022-03-21 13:00:00',
+                    environmentId: '1234567890',
+                    runType: 'technical',
+                    runQuality: 'good',
+                    nDetectors: 3,
+                    nFlps: 10,
+                    nEpns: 10,
+                    dd_flp: true,
+                    dcs: true,
+                    epn: true,
+                    epnTopology: 'normal',
+                    detectors: 'CPV,UNKNOWN',
+                })
+                .end((err, res) => {
+                    if (err) {
+                        done(err);
+                        return;
+                    }
+                    expect(res.body.errors).to.be.an('array');
+                    // eslint-disable-next-line max-len
+                    expect(res.body.errors[0].detail).to.equal('Error code "Provide detector list contains invalid elements" is not defined, your custom type is missing the correct messages definition');
+
+                    done();
+                });
+        });
+    });
 };

--- a/test/usecases/run/StartRunUseCase.test.js
+++ b/test/usecases/run/StartRunUseCase.test.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const { run: { StartRunUseCase } } = require('../../../lib/usecases');
+const { dtos: { StartRunDto } } = require('../../../lib/domain');
+const chai = require('chai');
+
+const { expect } = chai;
+
+module.exports = () => {
+    let startRunDto;
+
+    beforeEach(async () => {
+        startRunDto = await StartRunDto.validateAsync({
+            body: {
+                runNumber: 107,
+                timeO2Start: '2022-03-21 13:00:00',
+                timeTrgStart: '2022-03-21 13:00:00',
+                environmentId: '1234567890',
+                runType: 'technical',
+                runQuality: 'good',
+                nDetectors: 3,
+                nFlps: 10,
+                nEpns: 10,
+                dd_flp: true,
+                dcs: true,
+                epn: true,
+                epnTopology: 'normal',
+                detectors: 'CPV',
+            },
+        });
+    });
+    it('should successfully store and return the saved entity', async () => {
+        const { result } = await new StartRunUseCase()
+            .execute(startRunDto);
+        expect(result).to.be.an('object');
+        expect(result.id).to.equal(107);
+    });
+
+    it('should successfully store and return the saved entity with default values if not provided', async () => {
+        delete startRunDto.body.detectors;
+        startRunDto.body.runNumber = 108;
+        const { result } = await new StartRunUseCase()
+            .execute(startRunDto);
+        expect(result).to.be.an('object');
+        expect(result.id).to.equal(108);
+        expect(result.detectors).to.equal(null);
+    });
+};

--- a/test/usecases/run/StartRunUseCase.test.js
+++ b/test/usecases/run/StartRunUseCase.test.js
@@ -30,6 +30,8 @@ module.exports = () => {
                 runType: 'technical',
                 runQuality: 'good',
                 nDetectors: 3,
+                bytesReadOut: 1024,
+                nSubtimeframes: 10,
                 nFlps: 10,
                 nEpns: 10,
                 dd_flp: true,

--- a/test/usecases/run/index.js
+++ b/test/usecases/run/index.js
@@ -13,8 +13,10 @@
 
 const GetAllRunsUseCase = require('./GetAllRunsUseCase.test');
 const GetRunUseCase = require('./GetRunUseCase.test');
+const StartRunUseCase = require('./StartRunUseCase.test');
 
 module.exports = () => {
     describe('GetAllRunsUseCase', GetAllRunsUseCase);
     describe('GetRunUseCase', GetRunUseCase);
+    describe('StartRunUseCase', StartRunUseCase);
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

`runs.detectors` column was set to `ENUM` which only allowed one value to be set;
RUNS in AliECS can now accept multiple detectors so:
*  a validation is done on server side that it contains only accepted values
* `runs.detectors` columns is updated to `String` from `Enum`