### PR TITLE
[O2B-574] Add runs eor_reasons and reason_types tables

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,5 +1,17 @@
 # Bookkeeping data model
 
+- [Bookkeeping data model](#bookkeeping-data-model)
+  - [Introduction](#introduction)
+  - [Further explanations of fields tables](#further-explanations-of-fields-tables)
+  - [Runs](#runs)
+    - [End of run reasons](#end-of-run-reasons)
+      - [Reason Types (for EOR)](#reason-types-for-eor)
+  - [FLPs](#flps)
+  - [Log Entries](#log-entries)
+    - [Attachments](#attachments)
+  - [Users](#users)
+  - [Tags](#tags)
+  - [Environments](#environments)
 ## Introduction
 This document describes the data model of the ALICE O2 Bookkeeping system.   
 For simplicity, the following info is not described in this document: 
@@ -26,6 +38,7 @@ Concerning the **Update mode** of the fields:
 ## Runs
 
 **Description:** A Run is a synchronous data taking time period, performed in the O2 computing farm with a specific and well-defined configuration. It normally ranges from a few minutes to tens of hours and can include one or many ALICE detectors. It provides a unique identifier for the data set generated during the run.   
+**Relation:** `run` hasMany `eor_reasons`
 **DB main table**: `runs`   
 
 | **Field**                     | **Description**  | **Example** | **Update time** | **Update Key** | **Update mode** |
@@ -44,6 +57,35 @@ Concerning the **Update mode** of the fields:
 | `epn_topology`                | Path of the Global Processing topology deployed on the EPN nodes | `/home/epn/odc/dd-standalone-5.xml`  | At SOR | `run_number` | Insert |
 | `detectors`                   | List of detectors in the run | `ITS,TPC,TOF` | At SOR | `run_number` | Insert |
 
+
+### End of run reasons
+
+**Description:** EOR Reasons for which runs have ended. They contain a general reason_type and extra information with regards to user selecting it and other information
+**Relation:** `eor_reason` hasOne `reason_type`
+**DB main table**: `eor_reasons`
+
+| **Field**                     | **Description**  | **Example** | **Update time** | **Update Key** | **Update mode** |
+| ----------------------------- | ---------------- | ------------|-----------------|----------------|-----------------|
+| `id`                          | Auto-Incremented id for eor reason | `1`  | AT COE| `id` | Insert |
+| `description`                    | Other information on the reason | `Run stopped due to faulty detector`  | AT COE| `description` | Insert |
+| `reason_type_id`                    | Id of the general reason type belonging to | '1'  | AT COE| `reason_type_id` | Insert |
+| `run_id`                    | RUN id for which the reason was added | `500540`  | AT COE| `run_id` | Insert |
+| `last_edited_name`        | Name of the person who last edited the fields | `Anonymous`, `Jan Janssen` | When fields are edited | `id`| Update |
+| `created_at`                   | When the entity is created | | AT COE | `created_at`| Insert |
+| `updated_at`        | When entity is edited |  | When fields are edited | `updated_at`| Update |
+
+#### Reason Types (for EOR)
+
+**Description:** Reason Tpes for which runs have ended. This table describes general reasons categories and titles as per the RC criteria
+**DB main table**: `reason_types`
+
+| **Field**                     | **Description**  | **Example** | **Update time** | **Update Key** | **Update mode** |
+| ----------------------------- | ---------------- | ------------|-----------------|----------------|-----------------|
+| `id`                          | Auto-Incremented id for eor reason | `1`  | AT COE| `id` | Insert |
+| `category`                    | Category represented by a String | `Data Sanity and Quality`  | AT COE| `category` | Insert |
+| `title`                    | Title represented by a String | `Incomplete TF`  | AT COE| `title` | Insert |
+| `created_at`                   | When the entity is created | | AT COE | `created_at`| Insert |
+| `updated_at`        | When entity is edited |  | When fields are edited | `updated_at`| Update |
 
 ## FLPs
 
@@ -93,7 +135,7 @@ Concerning the **Update mode** of the fields:
 | `log_id`                      | ID of Log Entry to which the attachment belongs to. | `123` | At Log Entry creation | `id` | Insert |
 
 
-### Users
+## Users
 
 **Description:** Bookkeeping user. Used to identify the author of a Log Entry.   
 **DB main table**: `users`
@@ -104,7 +146,7 @@ Concerning the **Update mode** of the fields:
 | `name`                        | User full name.. |  | At first login | `id` | Insert |
 
 
-### Tags
+## Tags
 
 **Description:** Free text labels to add to Runs or Log Entries.    
 **DB main table**: `tags`
@@ -117,7 +159,7 @@ Concerning the **Update mode** of the fields:
 | `last_edited_name`        | Name of the person who last edited the email/mattermost fields | `Anonymous`, `Jan Janssen` | When email/mattermost is edited | `id`| Update |
 
 
-### Environments
+## Environments
 
 **Description:** The overall environment the runs are performed in.    
 **DB main table**: `envronments`
@@ -129,17 +171,3 @@ Concerning the **Update mode** of the fields:
 | `toredownAt`                  | When the environment is stopped | | AT EOE | `id`| Update |
 | `status`                      | Actual status of the envrionment | `STOPPED`, `STARTED`|  | `id`| Update |
 | `statusMessage`               | A bigger message to show more detail about the status | `Environment sucessfully closed`, `Error creating envrionment: bad configuration` | | `id`| Update |
-
-### End of run reasons
-
-**Description:** Reasons for which runs have ended
-**DB main table**: `eor_reasons`
-
-| **Field**                     | **Description**  | **Example** | **Update time** | **Update Key** | **Update mode** |
-| ----------------------------- | ---------------- | ------------|-----------------|----------------|-----------------|
-| `id`                          | Auto-Incremented id for eor reason | `1`  | AT COE| `id` | Insert |
-| `category`                    | Category represented by a String | `Data Sanity and Quality`  | AT COE| `category` | Insert |
-| `title`                    | Title represented by a String | `Incomplete TF`  | AT COE| `title` | Insert |
-| `last_edited_name`        | Name of the person who last edited the fields | `Anonymous`, `Jan Janssen` | When fields are edited | `id`| Update |
-| `created_at`                   | When the entity is created | | AT COE | `id`| Insert |
-| `updated_at`        | When entity is edited |  | When fields are edited | `id`| Update |

--- a/lib/database/adapters/EorReasonAdapter.js
+++ b/lib/database/adapters/EorReasonAdapter.js
@@ -22,18 +22,18 @@ class EorReasonAdapter {
      * @param {Object} databaseObject Object to convert.
      * @returns {Object} Converted entity object.
      */
-    static toEntity({ id, description, last_edited_name, reason_type_id, reason_type, createdAt, updatedAt }) {
+    static toEntity({ id, description, reasonTypeId, reasonType, lastEditedName, createdAt, updatedAt }) {
         const entityObject = {
             id,
             description,
-            reasonTypeId: reason_type_id,
-            lastEditedName: last_edited_name,
+            reasonTypeId,
+            lastEditedName,
             createdAt: new Date(createdAt).getTime(),
             updatedAt: new Date(updatedAt).getTime(),
         };
 
-        if (reason_type) {
-            const reasonType = ReasonTypeAdapter.toEntity(reason_type);
+        if (reasonType) {
+            const reasonType = ReasonTypeAdapter.toEntity(reasonType);
             entityObject.category = reasonType.category;
             entityObject.title = reasonType.title;
         }

--- a/lib/database/adapters/EorReasonAdapter.js
+++ b/lib/database/adapters/EorReasonAdapter.js
@@ -11,6 +11,8 @@
  * or submit itself to any jurisdiction.
  */
 
+const ReasonTypeAdapter = require('./ReasonTypeAdapter');
+
 /**
  * Eor(End of Run) Adapter
  */
@@ -20,24 +22,21 @@ class EorReasonAdapter {
      * @param {Object} databaseObject Object to convert.
      * @returns {Object} Converted entity object.
      */
-    static toEntity(databaseObject) {
-        const {
-            id,
-            category,
-            title,
-            lastEditedName,
-            createdAt,
-            updatedAt,
-        } = databaseObject;
-
+    static toEntity({ id, description, last_edited_name, reason_type_id, reason_type, createdAt, updatedAt }) {
         const entityObject = {
             id,
-            category,
-            title,
-            lastEditedName,
+            description,
+            reasonTypeId: reason_type_id,
+            lastEditedName: last_edited_name,
             createdAt: new Date(createdAt).getTime(),
             updatedAt: new Date(updatedAt).getTime(),
         };
+
+        if (reason_type) {
+            const reasonType = ReasonTypeAdapter.toEntity(reason_type);
+            entityObject.category = reasonType.category;
+            entityObject.title = reasonType.title;
+        }
         return entityObject;
     }
 
@@ -50,8 +49,9 @@ class EorReasonAdapter {
     static toDatabase(entityObject) {
         const databaseObject = {
             id: entityObject.id,
-            category: entityObject.category,
-            title: entityObject.title,
+            description: entityObject.description,
+            reasonTypeId: entityObject.reasonTypeId,
+            runId: entityObject.runId,
             lastEditedName: entityObject.lastEditedName,
             createdAt: entityObject.createdAt,
             updatedAt: entityObject.createdAt,

--- a/lib/database/adapters/ReasonTypeAdapter.js
+++ b/lib/database/adapters/ReasonTypeAdapter.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+/**
+ * ReasonType Adapter (Adapter used for selecting a reason for which a run was ended)
+ */
+class ReasonTypeAdapter {
+    /**
+     * Converts the given reason type database object to an entity object.
+     * @param {Object} databaseObject Object to convert.
+     * @returns {Object} Converted entity object.
+     */
+    static toEntity({ id, category, title }) {
+        const entityObject = {
+            id,
+            category,
+            title,
+        };
+        return entityObject;
+    }
+
+    /**
+     * Converts the given entity object to a reason type database object
+     *
+     * @param {Object} entityObject Object to convert.
+     * @returns {Object} Converted database object.
+     */
+    static toDatabase(entityObject) {
+        const databaseObject = {
+            id: entityObject.id,
+            category: entityObject.category,
+            title: entityObject.title,
+            createdAt: entityObject.createdAt,
+            updatedAt: entityObject.createdAt,
+        };
+        return databaseObject;
+    }
+}
+
+module.exports = ReasonTypeAdapter;

--- a/lib/database/adapters/RunAdapter.js
+++ b/lib/database/adapters/RunAdapter.js
@@ -76,7 +76,11 @@ class RunAdapter {
         };
 
         entityObject.tags = tags ? tags.map(TagAdapter.toEntity) : [];
-        entityObject.eorReasons = eor_reasons ? eor_reasons.map(EorReasonAdapter.toEntity) : [];
+
+        /*
+         * EorReasons will be enabled in next PR updating OpenAPI as well
+         * entityObject.eorReasons = eor_reasons ? eor_reasons.map(EorReasonAdapter.toEntity) : [];
+         */
 
         return entityObject;
     }

--- a/lib/database/adapters/RunAdapter.js
+++ b/lib/database/adapters/RunAdapter.js
@@ -11,7 +11,6 @@
  * or submit itself to any jurisdiction.
  */
 
-const EorReasonAdapter = require('./EorReasonAdapter');
 const TagAdapter = require('./TagAdapter');
 
 /**
@@ -46,7 +45,6 @@ class RunAdapter {
             epnTopology,
             detectors,
             tags,
-            eor_reasons,
             envId,
             updatedAt,
         } = databaseObject;
@@ -76,11 +74,6 @@ class RunAdapter {
         };
 
         entityObject.tags = tags ? tags.map(TagAdapter.toEntity) : [];
-
-        /*
-         * EorReasons will be enabled in next PR updating OpenAPI as well
-         * entityObject.eorReasons = eor_reasons ? eor_reasons.map(EorReasonAdapter.toEntity) : [];
-         */
 
         return entityObject;
     }

--- a/lib/database/adapters/RunAdapter.js
+++ b/lib/database/adapters/RunAdapter.js
@@ -11,6 +11,7 @@
  * or submit itself to any jurisdiction.
  */
 
+const EorReasonAdapter = require('./EorReasonAdapter');
 const TagAdapter = require('./TagAdapter');
 
 /**
@@ -45,6 +46,7 @@ class RunAdapter {
             epnTopology,
             detectors,
             tags,
+            eor_reasons,
             envId,
             updatedAt,
         } = databaseObject;
@@ -73,11 +75,8 @@ class RunAdapter {
             envId: envId,
         };
 
-        if (tags) {
-            entityObject.tags = tags.map(TagAdapter.toEntity);
-        } else {
-            entityObject.tags = [];
-        }
+        entityObject.tags = tags ? tags.map(TagAdapter.toEntity) : [];
+        entityObject.eorReasons = eor_reasons ? eor_reasons.map(EorReasonAdapter.toEntity) : [];
 
         return entityObject;
     }

--- a/lib/database/migrations/20220513075839-create-reason-type-table.js
+++ b/lib/database/migrations/20220513075839-create-reason-type-table.js
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+'use strict';
+/* eslint-disable valid-jsdoc */
+
+module.exports = {
+
+    /**
+     * Create a new table with its purpose to define the reasons for which a run was stopped
+     */
+    async up(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+        try {
+            await queryInterface.createTable('reason_types', {
+                id: {
+                    allowNull: false,
+                    primaryKey: true,
+                    autoIncrement: true,
+                    type: Sequelize.INTEGER,
+                },
+                category: {
+                    type: Sequelize.STRING,
+                },
+                title: {
+                    type: Sequelize.STRING,
+                },
+                created_at: {
+                    allowNull: false,
+                    type: Sequelize.DATE,
+                    defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+                },
+                updated_at: {
+                    allowNull: false,
+                    type: Sequelize.DATE,
+                    defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+                },
+            }, {
+                timestamps: true,
+            });
+            await transaction.commit();
+        } catch (err) {
+            await transaction.rollback();
+            throw err;
+        }
+    },
+
+    /**
+     * Revert above changes.
+     */
+    async down(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+        try {
+            await queryInterface.dropTable('reason_types');
+            await transaction.commit();
+        } catch (err) {
+            await transaction.rollback();
+            throw err;
+        }
+    },
+};

--- a/lib/database/migrations/20220513153414-crete-eor-reason-table.js
+++ b/lib/database/migrations/20220513153414-crete-eor-reason-table.js
@@ -29,16 +29,27 @@ module.exports = {
                     autoIncrement: true,
                     type: Sequelize.INTEGER,
                 },
-                category: {
+                description: {
                     type: Sequelize.STRING,
-                    allowNull: false,
-                },
-                title: {
-                    type: Sequelize.STRING,
-                    allowNull: true,
                 },
                 last_edited_name: {
                     type: Sequelize.STRING,
+                },
+                reason_type_id: {
+                    type: Sequelize.INTEGER,
+                    allowNull: false,
+                    references: {
+                        model: 'reason_types',
+                        key: 'id',
+                    },
+                },
+                run_id: {
+                    type: Sequelize.INTEGER,
+                    allowNull: false,
+                    references: {
+                        model: 'runs',
+                        key: 'id',
+                    },
                 },
                 created_at: {
                     allowNull: false,

--- a/lib/database/models/eorreason.js
+++ b/lib/database/models/eorreason.js
@@ -21,16 +21,17 @@ module.exports = (sequelize) => {
             autoIncrement: true,
             type: Sequelize.INTEGER,
         },
-        category: {
-            type: Sequelize.STRING,
-            allowNull: false,
-        },
-        title: {
-            allowNull: true,
+        description: {
             type: Sequelize.STRING,
         },
         last_edited_name: {
-            type: Sequelize.TEXT,
+            type: Sequelize.STRING,
+        },
+        reason_type_id: {
+            type: Sequelize.INTEGER,
+        },
+        run_id: {
+            type: Sequelize.INTEGER,
         },
         created_at: {
             allowNull: false,
@@ -43,6 +44,11 @@ module.exports = (sequelize) => {
             defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
         },
     });
+
+    EorReason.associate = (models) => {
+        EorReason.belongsTo(models.Run);
+        EorReason.belongsTo(models.ReasonType, { as: 'reason_type' });
+    };
 
     return EorReason;
 };

--- a/lib/database/models/eorreason.js
+++ b/lib/database/models/eorreason.js
@@ -24,21 +24,21 @@ module.exports = (sequelize) => {
         description: {
             type: Sequelize.STRING,
         },
-        last_edited_name: {
+        lastEditedName: {
             type: Sequelize.STRING,
         },
-        reason_type_id: {
+        reasonTypeId: {
             type: Sequelize.INTEGER,
         },
-        run_id: {
+        runId: {
             type: Sequelize.INTEGER,
         },
-        created_at: {
+        createdAt: {
             allowNull: false,
             type: Sequelize.DATE,
             defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
         },
-        updated_at: {
+        updatedAt: {
             allowNull: false,
             type: Sequelize.DATE,
             defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
@@ -47,7 +47,7 @@ module.exports = (sequelize) => {
 
     EorReason.associate = (models) => {
         EorReason.belongsTo(models.Run);
-        EorReason.belongsTo(models.ReasonType, { as: 'reason_type' });
+        EorReason.belongsTo(models.ReasonType, { as: 'reasonType' });
     };
 
     return EorReason;

--- a/lib/database/models/index.js
+++ b/lib/database/models/index.js
@@ -15,6 +15,7 @@ const Attachment = require('./attachment');
 const EpnRoleSession = require('./epnrolesession');
 const FlpRoles = require('./flprole');
 const Log = require('./log');
+const ReasonType = require('./reasontype');
 const Run = require('./run');
 const Subsystem = require('./subsystem');
 const Tag = require('./tag');
@@ -30,6 +31,7 @@ module.exports = (sequelize) => {
         EpnRoleSessionkey: EpnRoleSession(sequelize),
         FlpRoles: FlpRoles(sequelize),
         Log: Log(sequelize),
+        ReasonType: ReasonType(sequelize),
         Run: Run(sequelize),
         Subsystem: Subsystem(sequelize),
         Tag: Tag(sequelize),

--- a/lib/database/models/reasontype.js
+++ b/lib/database/models/reasontype.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+module.exports = (sequelize) => {
+    const Sequelize = require('sequelize');
+
+    const ReasonType = sequelize.define('ReasonType', {
+        id: {
+            allowNull: false,
+            primaryKey: true,
+            autoIncrement: true,
+            type: Sequelize.INTEGER,
+        },
+        category: {
+            type: Sequelize.STRING,
+        },
+        title: {
+            type: Sequelize.STRING,
+        },
+        created_at: {
+            allowNull: false,
+            type: Sequelize.DATE,
+            defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        },
+        updated_at: {
+            allowNull: false,
+            type: Sequelize.DATE,
+            defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+        },
+    });
+
+    return ReasonType;
+};

--- a/lib/database/models/reasontype.js
+++ b/lib/database/models/reasontype.js
@@ -27,12 +27,12 @@ module.exports = (sequelize) => {
         title: {
             type: Sequelize.STRING,
         },
-        created_at: {
+        createdAt: {
             allowNull: false,
             type: Sequelize.DATE,
             defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
         },
-        updated_at: {
+        updatedAt: {
             allowNull: false,
             type: Sequelize.DATE,
             defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),

--- a/lib/database/models/run.js
+++ b/lib/database/models/run.js
@@ -76,7 +76,7 @@ module.exports = (sequelize) => {
         Run.belongsToMany(models.Log, { through: 'log_runs' });
         Run.belongsToMany(models.FlpRoles, { through: 'flp_runs' });
         Run.belongsToMany(models.Tag, { through: 'run_tags', as: 'tags' });
-        Run.hasMany(models.EorReason, { as: 'eor_reasons' });
+        Run.hasMany(models.EorReason, { as: 'eorReasons' });
     };
 
     return Run;

--- a/lib/database/models/run.js
+++ b/lib/database/models/run.js
@@ -76,6 +76,7 @@ module.exports = (sequelize) => {
         Run.belongsToMany(models.Log, { through: 'log_runs' });
         Run.belongsToMany(models.FlpRoles, { through: 'flp_runs' });
         Run.belongsToMany(models.Tag, { through: 'run_tags', as: 'tags' });
+        Run.hasMany(models.EorReason, { as: 'eor_reasons' });
     };
 
     return Run;

--- a/lib/database/repositories/ReasonTypeRepository.js
+++ b/lib/database/repositories/ReasonTypeRepository.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const {
+    models: {
+        ReasonType,
+    },
+} = require('../');
+const Repository = require('./Repository');
+
+/**
+ * Sequelize implementation of the ReasonTypeRepository.
+ */
+class ReasonTypeRepository extends Repository {
+    /**
+     * Creates a new `ReasonTypeRepository` instance.
+     */
+    constructor() {
+        super(ReasonType);
+    }
+}
+
+module.exports = new ReasonTypeRepository();

--- a/lib/database/repositories/index.js
+++ b/lib/database/repositories/index.js
@@ -16,6 +16,7 @@ const EorReasonRepository = require('./EorReasonRepository');
 const LogRepository = require('./LogRepository');
 const LogTagsRepository = require('./LogTagsRepository');
 const RunRepository = require('./RunRepository');
+const ReasonTypeRepository = require('./ReasonTypeRepository');
 const SubsystemRepository = require('./SubsystemRepository');
 const TagRepository = require('./TagRepository');
 const UserRepository = require('./UserRepository');
@@ -30,6 +31,7 @@ module.exports = {
     LogRepository,
     LogTagsRepository,
     RunRepository,
+    ReasonTypeRepository,
     SubsystemRepository,
     TagRepository,
     UserRepository,

--- a/lib/database/seeders/20220513083459-reason-types.js
+++ b/lib/database/seeders/20220513083459-reason-types.js
@@ -14,42 +14,32 @@
 'use strict';
 
 module.exports = {
-    up: (queryInterface, _Sequelize) => queryInterface.bulkInsert('eor_reasons', [
+    up: (queryInterface, _Sequelize) => queryInterface.bulkInsert('reason_types', [
         {
             category: 'DETECTORS',
             title: 'CPV',
-            last_edited_name: 'Anonymous',
             created_at: new Date('2022-08-09'),
             updated_at: new Date('2022-08-10 15:00:00'),
         },
         {
             category: 'DETECTORS',
             title: 'TPC',
-            last_edited_name: 'Anonymous',
             created_at: new Date('2022-08-09'),
             updated_at: new Date('2022-08-10 05:00:00'),
         },
         {
-            category: 'Data Sanity and Quality',
-            title: 'Incomplete TF ',
-            last_edited_name: 'Anonymous',
+            category: 'OTHER',
+            title: 'Some-other',
             created_at: new Date('2021-08-09'),
             updated_at: new Date('2021-08-10 15:00:00'),
         },
         {
-            category: 'Data Sanity and Quality',
-            title: 'Rejected TF ',
-            last_edited_name: 'Anonymous',
+            category: 'OTHER',
+            title: '',
             created_at: new Date('2021-07-09'),
             updated_at: new Date('2021-07-10 15:00:00'),
         },
-        {
-            category: 'Other',
-            last_edited_name: 'Anonymous',
-            created_at: new Date('2020-08-09'),
-            updated_at: new Date('2020-08-10 15:00:00'),
-        },
     ]),
 
-    down: (queryInterface, _Sequelize) => queryInterface.bulkDelete('eor_reasons', null, {}),
+    down: (queryInterface, _Sequelize) => queryInterface.bulkDelete('reason_types', null, {}),
 };

--- a/lib/database/seeders/20220513153907-eor-reason.js
+++ b/lib/database/seeders/20220513153907-eor-reason.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+'use strict';
+
+module.exports = {
+    up: (queryInterface, _Sequelize) => queryInterface.bulkInsert('eor_reasons', [
+        {
+            description: 'Some Reason other than selected',
+            last_edited_name: 'Anonymous',
+            run_id: 1,
+            reason_type_id: 1,
+            created_at: new Date('2022-08-09'),
+            updated_at: new Date('2022-08-10 15:00:00'),
+        },
+        {
+            description: 'Some Reason other than selected plus one',
+            last_edited_name: 'Anonymous',
+            reason_type_id: 2,
+            run_id: 1,
+            created_at: new Date('2022-08-09'),
+            updated_at: new Date('2022-08-10 05:00:00'),
+        },
+        {
+            last_edited_name: 'Anonymous',
+            reason_type_id: 3,
+            run_id: 2,
+            created_at: new Date('2021-08-09'),
+            updated_at: new Date('2021-08-10 15:00:00'),
+        },
+        {
+            last_edited_name: 'Anonymous',
+            reason_type_id: 1,
+            run_id: 2,
+            created_at: new Date('2021-07-09'),
+            updated_at: new Date('2021-07-10 15:00:00'),
+        },
+        {
+            reason_type_id: 2,
+            run_id: 3,
+            created_at: new Date('2020-08-09'),
+            updated_at: new Date('2020-08-10 15:00:00'),
+        },
+    ]),
+
+    down: (queryInterface, _Sequelize) => queryInterface.bulkDelete('eor_reasons', null, {}),
+};


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

PR which:
* adds new models, adapters, migrations and seeders files for `eor_reasons` and `reason_type`
* database model documentation

A run has many `eor_reasons` while an `eor_reason` has one `reason_type`