### PR TITLE
[O2B-565] UpdateRunsUseCase to include eor reason and improve error response

### DIFF
--- a/lib/database/repositories/EorReasonRepository.js
+++ b/lib/database/repositories/EorReasonRepository.js
@@ -11,7 +11,11 @@
  * or submit itself to any jurisdiction.
  */
 
-const { EorReason } = require('./../models');
+const {
+    models: {
+        EorReason,
+    },
+} = require('./../');
 const Repository = require('./Repository');
 const EorReasonAdapter = require('./../adapters/EorReasonAdapter');
 
@@ -32,7 +36,7 @@ class EorReasonRepository extends Repository {
      * @return {Promise<void>} - delete result
      */
     async removeById(runId) {
-        return await EorReason.sequelize.getQueryInterface().bulkDelete('eor_reasons', { run_id: runId });
+        return await EorReason.destroy({ where: { run_id: runId } });
     }
 
     /**

--- a/lib/database/repositories/EorReasonRepository.js
+++ b/lib/database/repositories/EorReasonRepository.js
@@ -11,22 +11,38 @@
  * or submit itself to any jurisdiction.
  */
 
-const {
-    models: {
-        EorReason,
-    },
-} = require('../');
+const { EorReason } = require('./../models');
 const Repository = require('./Repository');
+const EorReasonAdapter = require('./../adapters/EorReasonAdapter');
 
 /**
- * Sequelize implementation of the EnvironmentRepository.
+ * Sequelize implementation of the EorReasonRepository.
  */
 class EorReasonRepository extends Repository {
     /**
-     * Creates a new `EnvironmentsRepository` instance.
+     * Creates a new `EorReasonRepository` instance.
      */
     constructor() {
         super(EorReason);
+    }
+
+    /**
+     * Remove all eor_reasons & runs relations by run id
+     * @param {number} runId  - run ID to delete eor_reasons for
+     * @return {Promise<void>} - delete result
+     */
+    async removeById(runId) {
+        return await EorReason.sequelize.getQueryInterface().bulkDelete('eor_reasons', { run_id: runId });
+    }
+
+    /**
+     * Add list of eor_reasons
+     * @param {Array<EorReason>} entities - Lists of end of run reasons to add
+     * @return {Promise<Array,Error>} Result of updating
+     */
+    async addMany(entities) {
+        entities = entities.map(EorReasonAdapter.toDatabase);
+        return await EorReason.bulkCreate(entities, { returning: true });
     }
 }
 

--- a/lib/domain/dtos/UpdateRunDto.js
+++ b/lib/domain/dtos/UpdateRunDto.js
@@ -31,7 +31,7 @@ const QueryDto = Joi.object({
 });
 
 const ParamsDto = Joi.object({
-    runId: Joi.string(),
+    runId: EntityIdDto.required(),
 });
 
 const UpdateRunDto = Joi.object({

--- a/lib/domain/dtos/UpdateRunDto.js
+++ b/lib/domain/dtos/UpdateRunDto.js
@@ -12,9 +12,18 @@
  */
 
 const Joi = require('joi');
+const EntityIdDto = require('./EntityIdDto');
+
+const EorReasonDto = Joi.object({
+    description: Joi.string().default(''),
+    lastEditedName: Joi.string().required(),
+    runId: EntityIdDto.required(),
+    reasonTypeId: EntityIdDto.required(),
+});
 
 const BodyDto = Joi.object({
     runQuality: Joi.string().valid('good', 'bad', 'test').default('test'),
+    eorReasons: Joi.array().min(0).items(EorReasonDto).optional(),
 });
 
 const QueryDto = Joi.object({

--- a/lib/usecases/run/UpdateRunUseCase.js
+++ b/lib/usecases/run/UpdateRunUseCase.js
@@ -14,6 +14,8 @@
 const {
     repositories: {
         RunRepository,
+        EorReasonRepository,
+        ReasonTypeRepository,
     },
     utilities: {
         TransactionHelper,
@@ -35,32 +37,76 @@ class UpdateRunUseCase {
     async execute(dto) {
         const { body, params } = dto;
         const { runId } = params;
-        const { runQuality, envId } = body;
 
-        await TransactionHelper.provide(async () => {
+        const { error } = await TransactionHelper.provide(async () => this._updateRun(runId, body));
+        if (error) {
+            return {
+                error: {
+                    status: '400',
+                    title: error.message || `Unable to update run with id ${runId}`,
+                },
+            };
+        }
+        const result = await new GetRunUseCase().execute({ params: { runId } });
+        return { result };
+    }
+
+    /**
+     * Method that given a set of KV pairs containing run related fields, will update the run accordingly
+     * @param {Number} runId - id of the run that needs to be updated;
+     * @param {JSON} runUpdates - KV pairs with fields from a run that should be updated and their new values;
+     * @returns {Promise<Run,Error>} Promise which shall resolve with updated RunObject or reject with specific error
+     */
+    async _updateRun(runId, runUpdates) {
+        try {
+            const { runQuality, envId, eorReasons } = runUpdates;
+
             const queryBuilder = new QueryBuilder().where('id').is(runId);
             const runObject = await RunRepository.findOne(queryBuilder);
 
-            if (runObject) {
+            if (!runObject) {
+                throw new Error(`run with this runId (${runId}) could not be found`);
+            } else {
                 if (runQuality) {
                     runObject.runQuality = runQuality;
                 }
                 if (envId) {
                     runObject.envId = envId;
                 }
+                if (eorReasons) {
+                    await this._updateEorReasonsOnRun(runId, eorReasons);
+                }
                 await runObject.save();
                 return runObject;
-            } else {
-                return {
-                    error: {
-                        status: '400',
-                        title: `run with this runId (${runId}) could not be found`,
-                    },
-                };
             }
-        });
-        const result = await new GetRunUseCase().execute({ params: { runId } });
-        return { result };
+        } catch (error) {
+            return {
+                error: {
+                    message: error.message || `unable to save updates on run with id: ${runId}`,
+                },
+            };
+        }
+    }
+
+    /**
+     * Method to remove existing reason_type - run_id from `eor_reasons` table and insert new ones
+     * @param {Number} runId - id of the run that is due to be modified
+     * @param {Array<EorReason>} eorReasons - list of eor_reasons to be updated on the RUN
+     * @returns {Run} - new run objects to be stored in the database
+     */
+    async _updateEorReasonsOnRun(runId, eorReasons) {
+        let reasonTypes = await ReasonTypeRepository.findAll();
+        reasonTypes = reasonTypes.map((reason) => reason.id);
+        const allReceivedReasonsExists = eorReasons.every((eorReason) => reasonTypes.includes(eorReason.reasonTypeId));
+        const allReasonsMatchRunId = eorReasons.every((eorReason) => eorReason.runId === runId);
+        if (!allReceivedReasonsExists) {
+            throw new Error('Provided reason types do not exist');
+        } else if (!allReasonsMatchRunId) {
+            throw new Error('Multiple run ids parameters passed in eorReasons list. Please send updates for one run only');
+        }
+
+        await EorReasonRepository.removeById(runId);
+        await EorReasonRepository.addMany(eorReasons);
     }
 }
 

--- a/lib/usecases/run/UpdateRunUseCase.js
+++ b/lib/usecases/run/UpdateRunUseCase.js
@@ -21,7 +21,7 @@ const {
         TransactionHelper,
         QueryBuilder,
     },
-} = require('../../database');
+} = require('./../../database');
 const GetRunUseCase = require('../run/GetRunUseCase');
 
 /**
@@ -42,8 +42,9 @@ class UpdateRunUseCase {
         if (error) {
             return {
                 error: {
-                    status: '400',
-                    title: error.message || `Unable to update run with id ${runId}`,
+                    status: 500,
+                    title: 'ServiceUnavailable',
+                    detail: error.message || `Unable to update run with id ${runId}`,
                 },
             };
         }

--- a/test/e2e/runs.test.js
+++ b/test/e2e/runs.test.js
@@ -477,4 +477,75 @@ module.exports = () => {
                 });
         });
     });
+
+    describe('PUT /api/runs/:runId', () => {
+        it('should successfully return the updated run entity with new runQuality value', async () => {
+            const { body } = await request(server)
+                .put('/api/runs/1')
+                .expect(201)
+                .send({
+                    runQuality: 'test',
+                });
+            expect(body.data).to.be.an('object');
+            expect(body.data.id).to.equal(1);
+            expect(body.data.runQuality).to.equal('test');
+        });
+
+        it('should return an error due to invalid runQuality value', async () => {
+            const { body } = await request(server)
+                .put('/api/runs/1')
+                .expect(400)
+                .send({
+                    runQuality: 'wrong',
+                });
+            expect(body.errors).to.be.an('array');
+            // eslint-disable-next-line max-len
+            expect(body.errors[0].detail).to.equal('"body.runQuality" must be one of [good, bad, test]');
+        });
+
+        it('should return an error due to invalid eorReasons list', async () => {
+            const { body } = await request(server)
+                .put('/api/runs/1')
+                .expect(400)
+                .send({
+                    eorReasons: [
+                        {
+                            description: 'Some',
+                            runId: '1a',
+                            reasonTypeId: 1,
+                            lastEditedName: 'Anonymous',
+                        },
+                    ],
+                });
+            expect(body.errors).to.be.an('array');
+            expect(body.errors[0].detail).to.equal('"body.eorReasons[0].runId" must be a number');
+        });
+
+        it('should successfully add eorReasons to run', async () => {
+            const currentRun = await request(server)
+                .get('/api/runs/106')
+                .expect(200);
+            expect(currentRun.body.data).to.be.an('object');
+            expect(currentRun.body.data.id).to.equal(106);
+            expect(currentRun.body.data.eorReasons).to.have.lengthOf(0);
+
+            const { body } = await request(server)
+                .put('/api/runs/106')
+                .expect(201)
+                .send({
+                    eorReasons: [
+                        {
+                            description: 'Some',
+                            runId: 106,
+                            reasonTypeId: 1,
+                            lastEditedName: 'Anonymous',
+                        },
+                    ],
+                });
+            expect(body.data).to.be.an('object');
+            expect(body.data.id).to.equal(106);
+            expect(body.data.eorReasons).to.have.lengthOf(1);
+            expect(body.data.eorReasons[0].description).to.equal('Some');
+        });
+    });
 };

--- a/test/usecases/run/UpdateRunUseCase.test.js
+++ b/test/usecases/run/UpdateRunUseCase.test.js
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const { run: { UpdateRunUseCase, GetRunUseCase } } = require('../../../lib/usecases');
+const { dtos: { UpdateRunDto, GetRunDto } } = require('../../../lib/domain');
+const chai = require('chai');
+
+const { expect } = chai;
+
+module.exports = () => {
+    let updateRunDto;
+    let getRunDto;
+
+    beforeEach(async () => {
+        updateRunDto = await UpdateRunDto.validateAsync({
+            body: {
+                runQuality: 'test',
+            },
+            params: {
+                runId: 106,
+            },
+        });
+        getRunDto = await GetRunDto.validateAsync({
+            params: {
+                runId: 106,
+            },
+        });
+    });
+
+    it('should successfully retrieve run via ID, store and return the new run with runQuality passed as to update fields', async () => {
+        const run = await new GetRunUseCase().execute(getRunDto);
+        expect(run).to.be.an('object');
+        expect(run.id).to.equal(106);
+        expect(run.runQuality).to.equal('good');
+
+        const { result, error } = await new UpdateRunUseCase().execute(updateRunDto);
+
+        expect(error).to.be.an('undefined');
+        expect(result).to.be.an('object');
+        expect(result.id).to.equal(106);
+        expect(result.runQuality).to.equal('test');
+    });
+
+    it('should successfully retrieve run via ID, store and return the new run with eorReasons passed as to update fields', async () => {
+        getRunDto.params.runId = 1;
+        const run = await new GetRunUseCase().execute(getRunDto);
+        expect(run).to.be.an('object');
+        expect(run.id).to.equal(1);
+        expect(run.eorReasons).to.have.lengthOf(2);
+        expect(run.eorReasons[0].description).to.equal('Some Reason other than selected');
+
+        updateRunDto.params.runId = 1;
+        updateRunDto.body = {
+            eorReasons: [
+                {
+                    description: 'Something went wrong',
+                    runId: 1,
+                    reasonTypeId: 1,
+                    lastEditedName: 'Anonymous',
+                },
+            ],
+        };
+        const { result, error } = await new UpdateRunUseCase().execute(updateRunDto);
+
+        expect(error).to.be.an('undefined');
+        expect(result).to.be.an('object');
+        expect(result.id).to.equal(1);
+        expect(result.eorReasons).to.have.lengthOf(1);
+        expect(result.eorReasons[0].description).to.equal('Something went wrong');
+    });
+
+    it('should return error if eor reasons do not match runId', async () => {
+        updateRunDto.params.runId = 10;
+        updateRunDto.body = {
+            eorReasons: [
+                {
+                    description: 'Something went wrong',
+                    runId: 1,
+                    reasonTypeId: 1,
+                    lastEditedName: 'Anonymous',
+                },
+            ],
+        };
+        const { result, error } = await new UpdateRunUseCase().execute(updateRunDto);
+
+        expect(result).to.be.an('undefined');
+
+        expect(error).to.be.an('object');
+        expect(error.status).to.equal(400);
+        expect(error.detail).to.equal('Multiple run ids parameters passed in eorReasons list. Please send updates for one run only');
+    });
+
+    it('should return error if eor reasons contain different runIds', async () => {
+        updateRunDto.params.runId = 1;
+        updateRunDto.body = {
+            eorReasons: [
+                {
+                    description: 'Something went wrong',
+                    runId: 1,
+                    reasonTypeId: 1,
+                    lastEditedName: 'Anonymous',
+                },
+                {
+                    description: 'Something went wrong',
+                    runId: 2,
+                    reasonTypeId: 1,
+                    lastEditedName: 'Anonymous',
+                },
+            ],
+        };
+        const { result, error } = await new UpdateRunUseCase().execute(updateRunDto);
+
+        expect(result).to.be.an('undefined');
+
+        expect(error).to.be.an('object');
+        expect(error.status).to.equal(400);
+        expect(error.detail).to.equal('Multiple run ids parameters passed in eorReasons list. Please send updates for one run only');
+    });
+
+    it('should return error if eor reasons contains reason_type_id that does not exist', async () => {
+        updateRunDto.params.runId = 1;
+        updateRunDto.body = {
+            eorReasons: [
+                {
+                    description: 'Something went wrong',
+                    runId: 1,
+                    reasonTypeId: 10,
+                    lastEditedName: 'Anonymous',
+                },
+            ],
+        };
+        const { result, error } = await new UpdateRunUseCase().execute(updateRunDto);
+
+        expect(result).to.be.an('undefined');
+
+        expect(error).to.be.an('object');
+        expect(error.status).to.equal(400);
+        expect(error.detail).to.equal('Provided reason types do not exist');
+    });
+};


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

PR Which:
* Extends the current `UpdateRunUseCase` to update `eor_reasons` table as well if passed within the run object
* Fixes error response as this was not being sent if update of the run failed;
* Adds tests accordingly