### PR TITLE
[O2B-565] EorReasons should be kept if id is provided for them

### DIFF
--- a/lib/database/repositories/EorReasonRepository.js
+++ b/lib/database/repositories/EorReasonRepository.js
@@ -18,6 +18,7 @@ const {
 } = require('./../');
 const Repository = require('./Repository');
 const EorReasonAdapter = require('./../adapters/EorReasonAdapter');
+const { Op } = require('sequelize');
 
 /**
  * Sequelize implementation of the EorReasonRepository.
@@ -31,12 +32,22 @@ class EorReasonRepository extends Repository {
     }
 
     /**
-     * Remove all eor_reasons & runs relations by run id
-     * @param {number} runId  - run ID to delete eor_reasons for
+     * Remove all eor_reasons & runs relations by one runId
+     * @param {Number} runId  - run ID to delete eor_reasons for
      * @return {Promise<void>} - delete result
      */
-    async removeById(runId) {
+    async removeByRunId(runId) {
         return await EorReason.destroy({ where: { run_id: runId } });
+    }
+
+    /**
+     * Remove all eor_reasons with passed run_id but which are not included in the list of entries id
+     * @param {Number} runId  - run ID to delete eor_reasons for
+     * @param {Array<Number>} ids  - list of ids for which entries should be kept
+     * @return {Promise<void>} - delete result
+     */
+    async removeByRunIdAndKeepIds(runId, ids) {
+        return await EorReason.destroy({ where: { [Op.and]: { run_id: runId, id: { [Op.ne]: ids } } } });
     }
 
     /**

--- a/lib/domain/dtos/UpdateRunDto.js
+++ b/lib/domain/dtos/UpdateRunDto.js
@@ -15,10 +15,15 @@ const Joi = require('joi');
 const EntityIdDto = require('./EntityIdDto');
 
 const EorReasonDto = Joi.object({
-    description: Joi.string().default(''),
+    description: Joi.string().allow(null, '').optional(),
     lastEditedName: Joi.string().required(),
     runId: EntityIdDto.required(),
     reasonTypeId: EntityIdDto.required(),
+    id: EntityIdDto.optional(),
+    category: Joi.string().optional(),
+    createdAt: Joi.date().timestamp().optional(),
+    title: Joi.string().optional(),
+    updatedAt: Joi.date().timestamp().optional(),
 });
 
 const BodyDto = Joi.object({

--- a/lib/usecases/run/UpdateRunUseCase.js
+++ b/lib/usecases/run/UpdateRunUseCase.js
@@ -106,8 +106,17 @@ class UpdateRunUseCase {
             throw new Error('Multiple run ids parameters passed in eorReasons list. Please send updates for one run only');
         }
 
-        await EorReasonRepository.removeById(runId);
-        await EorReasonRepository.addMany(eorReasons);
+        const toKeepEorReasons = []; // EorReasons with an ID already, means exist in DB;
+        const newEorReasons = []; // EorReasons with no ID, need to be added in DB;
+        eorReasons.forEach((eorReason) => {
+            if (eorReason.id) {
+                toKeepEorReasons.push(eorReason.id);
+            } else {
+                newEorReasons.push(eorReason);
+            }
+        });
+        await EorReasonRepository.removeByRunIdAndKeepIds(runId, toKeepEorReasons);
+        await EorReasonRepository.addMany(newEorReasons);
     }
 }
 

--- a/test/usecases/run/UpdateRunUseCase.test.js
+++ b/test/usecases/run/UpdateRunUseCase.test.js
@@ -60,10 +60,23 @@ module.exports = () => {
         expect(run.eorReasons[0].description).to.equal('Some Reason other than selected');
 
         updateRunDto.params.runId = 1;
+
+        /*
+         * EorReasons with ID should be kept, those without ID should be inserted, existing EoRReasons in entry not matching
+         * this condition should be removed
+         */
         updateRunDto.body = {
             eorReasons: [
                 {
-                    description: 'Something went wrong',
+                    runId: 1,
+                    reasonTypeId: 1,
+                    lastEditedName: 'Anonymous',
+                },
+                {
+                    id: 1,
+                    title: 'DETECTORS',
+                    category: 'CPV',
+                    description: 'Some Reason other than selected',
                     runId: 1,
                     reasonTypeId: 1,
                     lastEditedName: 'Anonymous',
@@ -75,8 +88,11 @@ module.exports = () => {
         expect(error).to.be.an('undefined');
         expect(result).to.be.an('object');
         expect(result.id).to.equal(1);
-        expect(result.eorReasons).to.have.lengthOf(1);
-        expect(result.eorReasons[0].description).to.equal('Something went wrong');
+        expect(result.eorReasons).to.have.lengthOf(2);
+        expect(result.eorReasons[0].id).to.equal(1);
+        expect(result.eorReasons[0].description).to.equal('Some Reason other than selected');
+        expect(result.eorReasons[1].id).to.equal(6);
+        expect(result.eorReasons[1].description).to.be.null;
     });
 
     it('should return error if eor reasons do not match runId', async () => {
@@ -96,7 +112,7 @@ module.exports = () => {
         expect(result).to.be.an('undefined');
 
         expect(error).to.be.an('object');
-        expect(error.status).to.equal(400);
+        expect(error.status).to.equal(500);
         expect(error.detail).to.equal('Multiple run ids parameters passed in eorReasons list. Please send updates for one run only');
     });
 
@@ -123,7 +139,7 @@ module.exports = () => {
         expect(result).to.be.an('undefined');
 
         expect(error).to.be.an('object');
-        expect(error.status).to.equal(400);
+        expect(error.status).to.equal(500);
         expect(error.detail).to.equal('Multiple run ids parameters passed in eorReasons list. Please send updates for one run only');
     });
 
@@ -144,7 +160,7 @@ module.exports = () => {
         expect(result).to.be.an('undefined');
 
         expect(error).to.be.an('object');
-        expect(error.status).to.equal(400);
+        expect(error.status).to.equal(500);
         expect(error.detail).to.equal('Provided reason types do not exist');
     });
 };

--- a/test/usecases/run/index.js
+++ b/test/usecases/run/index.js
@@ -15,10 +15,12 @@ const GetAllReasonTypesUseCase = require('./GetAllReasonTypesUseCase.test');
 const GetAllRunsUseCase = require('./GetAllRunsUseCase.test');
 const GetRunUseCase = require('./GetRunUseCase.test');
 const StartRunUseCase = require('./StartRunUseCase.test');
+const UpdateRunUseCase = require('./UpdateRunUseCase.test');
 
 module.exports = () => {
     describe('GetAllReasonTypesUseCase', GetAllReasonTypesUseCase);
     describe('GetAllRunsUseCase', GetAllRunsUseCase);
     describe('GetRunUseCase', GetRunUseCase);
     describe('StartRunUseCase', StartRunUseCase);
+    describe('UpdateRunUseCase', UpdateRunUseCase);
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

When passing `eorReasons` to the `PUT /api/runs/:runId`, if the body contains eorReasons list with entries:
* with `id`, it means, those eorReasons are already in the DB and should be kept
* without `id` it means, those eorReasons are new and need to be inserted in DB
* rest already existing eorReasons for that `runId` should be deleted from the DB;