### PR TITLE
[O2B-657] Store lhcPeriod value in runs

### DIFF
--- a/database/CHANGELOG.md
+++ b/database/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.3X.X]
+## [0.35.0]
 * Changes made to the database:
     * table `runs` - added fields:
         * `lhcPeriod` - string ('lhc22_b')

--- a/database/CHANGELOG.md
+++ b/database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3X.X]
+* Changes made to the database:
+    * table `runs` - added fields:
+        * `lhcPeriod` - string ('')
 ## [0.32.0]
 * Changes made to the database:
     * table `runs` - added fields:

--- a/database/CHANGELOG.md
+++ b/database/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [0.3X.X]
 * Changes made to the database:
     * table `runs` - added fields:
-        * `lhcPeriod` - string ('')
+        * `lhcPeriod` - string ('lhc22_b')
 ## [0.32.0]
 * Changes made to the database:
     * table `runs` - added fields:

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -69,6 +69,7 @@ Concerning the **Update mode** of the fields:
 | `pdpConfigOption`                    | Configuration option PDP             | `Repository Hash`                   |  | `run_number` | Update |
 | `pdpTopologyDescriptionLibraryFile`  | File location of the pdp topology    | `some/location.desc`                |  | `run_number` | Update |
 | `tfbDdMode`                          | The mode of the TFB DD               | `processing`                        |  | `run_number` | Update |
+| `lhcPeriod`                          | The period value of the lhc          | ` `                        |  | `run_number` | Update |
 
 ### End of run reasons
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -69,7 +69,7 @@ Concerning the **Update mode** of the fields:
 | `pdpConfigOption`                    | Configuration option PDP             | `Repository Hash`                   |  | `run_number` | Update |
 | `pdpTopologyDescriptionLibraryFile`  | File location of the pdp topology    | `some/location.desc`                |  | `run_number` | Update |
 | `tfbDdMode`                          | The mode of the TFB DD               | `processing`                        |  | `run_number` | Update |
-| `lhcPeriod`                          | The period value of the lhc          | ` `                        |  | `run_number` | Update |
+| `lhcPeriod`                          | The period value of the lhc          | `lhc22_b`                           |  | `run_number` | Update |
 
 ### End of run reasons
 

--- a/go-api-client/Example.go
+++ b/go-api-client/Example.go
@@ -18,12 +18,12 @@ func main() {
 	// TODO: generate correct JWT token instead of manual insertion
 	apiClient.InitializeApi(baseUrl, apiToken)
 
-	// Create a run
+	// // Create a run
 	apiClient.CreateRun("go-api-Timestamp", 5, 5, 1, 80, sw.COSMICS_RunType, false, false, true, "normal",
 		(sw.CPV_Detectors + "," + sw.ZDC_Detectors + "," + sw.EMC_Detectors))
 
 	// Update a run
-	apiClient.UpdateRun(80, sw.BAD_RunQuality, -1, testTime, -1, testTime, false, false, "Repository Hash", "production/production.desc", "processing")
+	apiClient.UpdateRun(80, sw.BAD_RunQuality, -1, testTime, -1, testTime, false, false, "Repository Hash", "production/production.desc", "processing", "123123123")
 
 	// Create an flp
 	apiClient.CreateFlp("flpTestName", "flpTestHost", 80)
@@ -34,9 +34,9 @@ func main() {
 	// Create a log
 	apiClient.CreateLog("logTest", "logTest", "80", -1)
 
-	// // Retrieve all logs from the api
+	// Retrieve all logs from the api
 	apiClient.GetLogs()
 
-	// // Retrieve all runs from the api
+	// Retrieve all runs from the api
 	apiClient.GetRuns()
 }

--- a/go-api-client/Example.go
+++ b/go-api-client/Example.go
@@ -18,12 +18,12 @@ func main() {
 	// TODO: generate correct JWT token instead of manual insertion
 	apiClient.InitializeApi(baseUrl, apiToken)
 
-	// // Create a run
+	// Create a run
 	apiClient.CreateRun("go-api-Timestamp", 5, 5, 1, 80, sw.COSMICS_RunType, false, false, true, "normal",
 		(sw.CPV_Detectors + "," + sw.ZDC_Detectors + "," + sw.EMC_Detectors))
 
 	// Update a run
-	apiClient.UpdateRun(80, sw.BAD_RunQuality, -1, testTime, -1, testTime, false, false, "Repository Hash", "production/production.desc", "processing", "123123123")
+	apiClient.UpdateRun(80, sw.BAD_RunQuality, -1, testTime, -1, testTime, false, false, "Repository Hash", "production/production.desc", "processing", "lhc22_b")
 
 	// Create an flp
 	apiClient.CreateFlp("flpTestName", "flpTestHost", 80)

--- a/go-api-client/openapi-source.yaml
+++ b/go-api-client/openapi-source.yaml
@@ -1693,6 +1693,9 @@ components:
           type: integer
           format: int32
           example: 853113599
+        lhcPeriod:
+          description: A string that marks the period of the lhc
+          type: string
       additionalProperties: false
     RunEnvironmentId:
       description: The unique identifier of this entity.

--- a/go-api-client/src/BookkeepingApi.go
+++ b/go-api-client/src/BookkeepingApi.go
@@ -82,7 +82,7 @@ func CreateRun(environmentId string, nDetectors int32, nEpns int32, nFlps int32,
  * @param triggerEnd (UTC) Time when Trigger subsystem was stopped
  */
 func UpdateRun(runNumber int32, runQuality sw.RunQuality, timeO2Start int64, timeO2End int64, timeTrgStart int64, timeTrgEnd int64,
-	trgGlobalRunEnabled bool, trgEnabled bool, pdpConfigOption string, pdpTopologyDescriptionLibraryFile string, tfbDdMode string) (sw.RunResponse, *http.Response, error) {
+	trgGlobalRunEnabled bool, trgEnabled bool, pdpConfigOption string, pdpTopologyDescriptionLibraryFile string, tfbDdMode string, lhcPeriod string) (sw.RunResponse, *http.Response, error) {
 	var runquality sw.RunQuality = runQuality
 	obj := sw.Run{
 		RunQuality:                        &runquality,
@@ -91,6 +91,7 @@ func UpdateRun(runNumber int32, runQuality sw.RunQuality, timeO2Start int64, tim
 		PdpConfigOption:                   pdpConfigOption,
 		PdpTopologyDescriptionLibraryFile: pdpTopologyDescriptionLibraryFile,
 		TfbDdMode:                         tfbDdMode,
+		LhcPeriod:                         lhcPeriod,
 	}
 	if timeO2End != -1 {
 		obj.TimeO2End = timeO2End

--- a/go-api-client/src/go-client-generated/api/swagger.yaml
+++ b/go-api-client/src/go-client-generated/api/swagger.yaml
@@ -1174,6 +1174,7 @@ components:
             tfbDdMode: processing
             updatedAt: 853113599
             epn: false
+            lhcPeriod: lhcPeriod
             timeTrgStart: 853113599
             pdpConfigOption: pdpConfigOption
             nSubtimeframes: 2
@@ -1200,6 +1201,7 @@ components:
             tfbDdMode: processing
             updatedAt: 853113599
             epn: false
+            lhcPeriod: lhcPeriod
             timeTrgStart: 853113599
             pdpConfigOption: pdpConfigOption
             nSubtimeframes: 2
@@ -1233,6 +1235,7 @@ components:
             tfbDdMode: processing
             updatedAt: 853113599
             epn: false
+            lhcPeriod: lhcPeriod
             timeTrgStart: 853113599
             pdpConfigOption: pdpConfigOption
             nSubtimeframes: 2
@@ -1259,6 +1262,7 @@ components:
             tfbDdMode: processing
             updatedAt: 853113599
             epn: false
+            lhcPeriod: lhcPeriod
             timeTrgStart: 853113599
             pdpConfigOption: pdpConfigOption
             nSubtimeframes: 2
@@ -1554,6 +1558,7 @@ components:
           tfbDdMode: processing
           updatedAt: 853113599
           epn: false
+          lhcPeriod: lhcPeriod
           timeTrgStart: 853113599
           pdpConfigOption: pdpConfigOption
           nSubtimeframes: 2
@@ -1580,6 +1585,7 @@ components:
           tfbDdMode: processing
           updatedAt: 853113599
           epn: false
+          lhcPeriod: lhcPeriod
           timeTrgStart: 853113599
           pdpConfigOption: pdpConfigOption
           nSubtimeframes: 2
@@ -1927,6 +1933,7 @@ components:
           tfbDdMode: processing
           updatedAt: 853113599
           epn: false
+          lhcPeriod: lhcPeriod
           timeTrgStart: 853113599
           pdpConfigOption: pdpConfigOption
           nSubtimeframes: 2
@@ -1953,6 +1960,7 @@ components:
           tfbDdMode: processing
           updatedAt: 853113599
           epn: false
+          lhcPeriod: lhcPeriod
           timeTrgStart: 853113599
           pdpConfigOption: pdpConfigOption
           nSubtimeframes: 2
@@ -2004,6 +2012,7 @@ components:
             tfbDdMode: processing
             updatedAt: 853113599
             epn: false
+            lhcPeriod: lhcPeriod
             timeTrgStart: 853113599
             pdpConfigOption: pdpConfigOption
             nSubtimeframes: 2
@@ -2030,6 +2039,7 @@ components:
             tfbDdMode: processing
             updatedAt: 853113599
             epn: false
+            lhcPeriod: lhcPeriod
             timeTrgStart: 853113599
             pdpConfigOption: pdpConfigOption
             nSubtimeframes: 2
@@ -2822,6 +2832,9 @@ components:
           description: Unix timestamp when this entity was last updated.
           format: int32
           example: 853113599
+        lhcPeriod:
+          type: string
+          description: A string that marks the period of the lhc
       additionalProperties: false
       description: Describes an intervention or an event that happened.
       example:
@@ -2841,6 +2854,7 @@ components:
         tfbDdMode: processing
         updatedAt: 853113599
         epn: false
+        lhcPeriod: lhcPeriod
         timeTrgStart: 853113599
         pdpConfigOption: pdpConfigOption
         nSubtimeframes: 2
@@ -2924,6 +2938,7 @@ components:
           tfbDdMode: processing
           updatedAt: 853113599
           epn: false
+          lhcPeriod: lhcPeriod
           timeTrgStart: 853113599
           pdpConfigOption: pdpConfigOption
           nSubtimeframes: 2

--- a/go-api-client/src/go-client-generated/docs/Run.md
+++ b/go-api-client/src/go-client-generated/docs/Run.md
@@ -29,6 +29,7 @@ Name | Type | Description | Notes
 **EpnTopology** | **string** |  | [optional] [default to null]
 **Detectors** | [***Detectors**](DETECTORS.md) |  | [optional] [default to null]
 **UpdatedAt** | **int32** | Unix timestamp when this entity was last updated. | [optional] [default to null]
+**LhcPeriod** | **string** | A string that marks the period of the lhc | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/go-api-client/src/go-client-generated/model_run.go
+++ b/go-api-client/src/go-client-generated/model_run.go
@@ -42,4 +42,6 @@ type Run struct {
 	Detectors *Detectors `json:"detectors,omitempty"`
 	// Unix timestamp when this entity was last updated.
 	UpdatedAt int32 `json:"updatedAt,omitempty"`
+	// A string that marks the period of the lhc
+	LhcPeriod string `json:"lhcPeriod,omitempty"`
 }

--- a/lib/database/adapters/RunAdapter.js
+++ b/lib/database/adapters/RunAdapter.js
@@ -63,6 +63,7 @@ class RunAdapter {
             pdpConfigOption,
             pdpTopologyDescriptionLibraryFile,
             tfbDdMode,
+            lhcPeriod,
         } = databaseObject;
 
         const entityObject = {
@@ -101,7 +102,7 @@ class RunAdapter {
             pdpConfigOption: pdpConfigOption,
             pdpTopologyDescriptionLibraryFile: pdpTopologyDescriptionLibraryFile,
             tfbDdMode: tfbDdMode,
-
+            lhcPeriod: lhcPeriod,
         };
 
         entityObject.tags = tags ? tags.map(TagAdapter.toEntity) : [];

--- a/lib/database/migrations/20220726074211-runs-lhc-period.js
+++ b/lib/database/migrations/20220726074211-runs-lhc-period.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => queryInterface.sequelize.transaction((t) => Promise.all([
+        queryInterface.addColumn('runs', 'lhc_period', {
+            type: Sequelize.DataTypes.CHAR(64),
+            allowNull: true,
+            default: null,
+        }, { transaction: t }),
+    ])),
+
+    down: async (queryInterface, _Sequelize) => queryInterface.sequelize.transaction((t) =>
+        Promise.all([queryInterface.removeColumn('runs', 'lhc_period', { transaction: t })])),
+};

--- a/lib/database/models/run.js
+++ b/lib/database/models/run.js
@@ -122,6 +122,9 @@ module.exports = (sequelize) => {
             type: Sequelize.CHAR(64),
             default: null,
         },
+        lhcPeriod: {
+            type: Sequelize.CHAR(64),
+        },
     });
 
     Run.associate = (models) => {

--- a/lib/database/seeders/20200713103855-runs.js
+++ b/lib/database/seeders/20200713103855-runs.js
@@ -34,6 +34,7 @@ module.exports = {
             fill_number: 5,
             epn_topology: 'normal',
             detectors: 'CPV',
+            lhc_period: 'lhc22_b',
         },
         {
             id: 2,
@@ -55,6 +56,7 @@ module.exports = {
             fill_number: 5,
             epn_topology: 'normal',
             detectors: 'CPV',
+            lhc_period: 'lhc22_b',
         },
         {
             id: 3,

--- a/lib/domain/dtos/EndRunDto.js
+++ b/lib/domain/dtos/EndRunDto.js
@@ -24,6 +24,7 @@ const BodyDto = Joi.object({
     pdpTopologyDescriptionLibraryFile: Joi.string().optional(),
     tfbDdMode: Joi.string().optional().max(64),
     runQuality: Joi.string().valid('good', 'bad', 'test').optional(),
+    lhcPeriod: Joi.string().optional(),
 });
 
 const QueryDto = Joi.object({

--- a/spec/openapi-source.yaml
+++ b/spec/openapi-source.yaml
@@ -2070,6 +2070,10 @@ components:
           description: LHC Beta * in meters
           type: number
           nullable: true
+        lhcPeriod:
+          description: The period tag of an LHC
+          type: string
+          nullable: true
         nDetectors:
           $ref: '#/components/schemas/RunDetectors'
         nEpns:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,4 +1,4 @@
-# Generated on Thu, 14 Jul 2022 10:11:27 GMT
+# Generated on Tue, 26 Jul 2022 09:42:04 GMT
 
 openapi: 3.0.0
 info:
@@ -2071,6 +2071,10 @@ components:
         lhcBetaStar:
           description: LHC Beta * in meters
           type: number
+          nullable: true
+        lhcPeriod:
+          description: The period tag of an LHC
+          type: string
           nullable: true
         nDetectors:
           $ref: '#/components/schemas/RunDetectors'

--- a/test/e2e/runs.test.js
+++ b/test/e2e/runs.test.js
@@ -784,7 +784,7 @@ module.exports = () => {
                     trgEnabled: false,
                     pdpTopologyDescriptionLibraryFile: 'production/production.desc',
                     tfbDdMode: 'processing',
-                    lhcPeriod: '123123123',
+                    lhcPeriod: 'lhc22_b',
                 });
             expect(body.data).to.be.an('object');
             expect(body.data.timeO2End).to.equal(dateValue);
@@ -797,7 +797,7 @@ module.exports = () => {
             expect(body.data.trgEnabled).to.equal(false);
             expect(body.data.pdpTopologyDescriptionLibraryFile).to.equal('production/production.desc');
             expect(body.data.tfbDdMode).to.equal('processing');
-            expect(body.data.lhcPeriod).to.equal('123123123');
+            expect(body.data.lhcPeriod).to.equal('lhc22_b');
         });
     });
 };

--- a/test/e2e/runs.test.js
+++ b/test/e2e/runs.test.js
@@ -752,6 +752,7 @@ module.exports = () => {
                     timeO2End: dateValue,
                     timeTrgEnd: dateValue,
                     runQuality: 'test',
+                    lhcPeriod: '123123123',
                 })
                 .expect(201)
                 .end((err, res) => {
@@ -764,10 +765,11 @@ module.exports = () => {
                     expect(res.body.data.timeO2End).to.equal(dateValue);
                     expect(res.body.data.timeTrgEnd).to.equal(dateValue);
                     expect(res.body.data.runQuality).to.equal('test');
+                    expect(res.body.data.lhcPeriod).to.equal('123123123');
                     done();
                 });
         });
-        it('should be able to update with ', async () => {
+        it('should be able to update with lhc values', async () => {
             const { body } = await request(server)
                 .patch('/api/runs/80')
                 .expect(201)
@@ -782,6 +784,7 @@ module.exports = () => {
                     trgEnabled: false,
                     pdpTopologyDescriptionLibraryFile: 'production/production.desc',
                     tfbDdMode: 'processing',
+                    lhcPeriod: '123123123',
                 });
             expect(body.data).to.be.an('object');
             expect(body.data.timeO2End).to.equal(dateValue);
@@ -794,6 +797,7 @@ module.exports = () => {
             expect(body.data.trgEnabled).to.equal(false);
             expect(body.data.pdpTopologyDescriptionLibraryFile).to.equal('production/production.desc');
             expect(body.data.tfbDdMode).to.equal('processing');
+            expect(body.data.lhcPeriod).to.equal('123123123');
         });
     });
 };

--- a/test/e2e/runs.test.js
+++ b/test/e2e/runs.test.js
@@ -752,7 +752,7 @@ module.exports = () => {
                     timeO2End: dateValue,
                     timeTrgEnd: dateValue,
                     runQuality: 'test',
-                    lhcPeriod: '123123123',
+                    lhcPeriod: 'lhc22_b',
                 })
                 .expect(201)
                 .end((err, res) => {
@@ -765,11 +765,11 @@ module.exports = () => {
                     expect(res.body.data.timeO2End).to.equal(dateValue);
                     expect(res.body.data.timeTrgEnd).to.equal(dateValue);
                     expect(res.body.data.runQuality).to.equal('test');
-                    expect(res.body.data.lhcPeriod).to.equal('123123123');
+                    expect(res.body.data.lhcPeriod).to.equal('lhc22_b');
                     done();
                 });
         });
-        it('should be able to update with lhc values', async () => {
+        it('should be able to update with multiple run values', async () => {
             const { body } = await request(server)
                 .patch('/api/runs/80')
                 .expect(201)

--- a/test/usecases/run/EndRunUseCase.test.js
+++ b/test/usecases/run/EndRunUseCase.test.js
@@ -36,7 +36,7 @@ module.exports = () => {
                 trgEnabled: false,
                 pdpTopologyDescriptionLibraryFile: 'production/production.desc',
                 tfbDdMode: 'processing',
-                lhcPeriod: '123123123',
+                lhcPeriod: 'lhc22_b',
             },
         });
 
@@ -58,7 +58,7 @@ module.exports = () => {
         expect(result.trgEnabled).to.equal(false);
         expect(result.pdpTopologyDescriptionLibraryFile).to.equal('production/production.desc');
         expect(result.tfbDdMode).to.equal('processing');
-        expect(result.lhcPeriod).to.equal('123123123');
+        expect(result.lhcPeriod).to.equal('lhc22_b');
     });
 
     it('Should give an error when the id of the environment can not be found', async () => {

--- a/test/usecases/run/EndRunUseCase.test.js
+++ b/test/usecases/run/EndRunUseCase.test.js
@@ -36,6 +36,7 @@ module.exports = () => {
                 trgEnabled: false,
                 pdpTopologyDescriptionLibraryFile: 'production/production.desc',
                 tfbDdMode: 'processing',
+                lhcPeriod: '123123123',
             },
         });
 
@@ -57,6 +58,7 @@ module.exports = () => {
         expect(result.trgEnabled).to.equal(false);
         expect(result.pdpTopologyDescriptionLibraryFile).to.equal('production/production.desc');
         expect(result.tfbDdMode).to.equal('processing');
+        expect(result.lhcPeriod).to.equal('123123123');
     });
 
     it('Should give an error when the id of the environment can not be found', async () => {


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected
- [X] `CHANGELOG.md` and `database/CHANGELOG.md` files were updated

CHANGELOG will be updated with ticket O2B-627

Extra field is added within the run table:
`lhcPeriod` - string

This period can be updated by using the endpoint PATCH api/runs/:id