### PR TITLE
Release/0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [WIP] [0.35.0](https://github.com/AliceO2Group/Bookkeeping/releases/tag/%40aliceo2%2Fbookkeeping%400.35.0)
+## [0.35.0](https://github.com/AliceO2Group/Bookkeeping/releases/tag/%40aliceo2%2Fbookkeeping%400.35.0)
 * Notable changes for users:
   * Fixes a bug in which updating EOR reasons for a run, would change the `RunQuality` back to default;
   * Run LHC period, number of EPNs are now shown in the run details and can be exported via the export runs tab;
   * `trgEnabled` + `trgGlobalRunEnabled` are now shown as `triggerValue` and has the values `OFF or LTU or CTP`;
+  * Notification service will now include `runNumbers` when used together with creating a log;
 * Notable changes for developers:
   * `GET` Runs API:
     * `lhcPeriods` Runs can now be filtered by using the `lhcPeriods` field. Multiple values can be used with comma seperation;

--- a/database/CHANGELOG.md
+++ b/database/CHANGELOG.md
@@ -2,6 +2,8 @@
 * Changes made to the database:
     * table `runs` - added fields:
         * `lhcPeriod` - string ('lhc22_b')
+        * `nEpns` - number
+        * `trigger_value` - enum (OFF, CTP, LTU)
 ## [0.32.0]
 * Changes made to the database:
     * table `runs` - added fields:

--- a/lib/public/views/About/Overview/index.js
+++ b/lib/public/views/About/Overview/index.js
@@ -21,7 +21,7 @@ import table from '../../../components/Table/index.js';
  */
 const aboutOverview = () => {
     const data = [
-        { type: 'Bookkeeping', version: '0.34.0', hostname: '-', port: '4000' },
+        { type: 'Bookkeeping', version: '0.35.0', hostname: '-', port: '4000' },
         { type: 'NPM', version: '', hostname: '', port: '' },
     ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/bookkeeping",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/bookkeeping",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "cls-hooked",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/bookkeeping",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "author": "ALICEO2",
   "scripts": {
     "coverage": "nyc npm test && npm run coverage:report",


### PR DESCRIPTION
  * Fixes a bug in which updating EOR reasons for a run, would change the `RunQuality` back to default;
  * `lhcPeriod`, `number of EPNs` are now shown in the run details and run overview and can be exported via the export runs tab;
  * `trgEnabled` + `trgGlobalRunEnabled` are now shown as `triggerValue` and has the values `OFF or LTU or CTP`;
  * Notification service will now include `runNumbers` when used together with creating a log;