### PR TITLE
Fix for empty run type

### DIFF
--- a/lib/public/utilities/formatting/formatRunType.js
+++ b/lib/public/utilities/formatting/formatRunType.js
@@ -19,8 +19,8 @@
  * @returns {string} The name or id or a '-' if null
  */
 export function formatRunType(runType) {
-    if (typeof runType === 'string') {
-        return runType;
+    if (runType) {
+        return runType.name ? runType.name : runType;
     }
-    return runType.name ? runType.name : '-';
+    return '-';
 }


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [x] tests are added
- [x] documentation was updated or added

Fixes the bug where there are no run types.

To replicate this remove the `up` function in run type seeder for an empty function: 
`up: async ({ context: { queryInterface } }) =>{},`

and comment out all the `run_type_id` values within the run seeder.
Re-seed the database and open a run or run overview on the webpage.