### PR TITLE
Update PR template for new changelog system

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,5 +16,12 @@ Remove checklist and/or items that do not apply.
 - [ ] issue has "Fix version" assigned
 - [ ] issue "Status" is set to "In review"
 - [ ] PR labels are selected
-- [ ] `CHANGELOG.md` and `database/CHANGELOG.md` files were updated
 
+Notable changes for users:
+-
+
+Notable changes for develops:
+-
+
+Changes made to the database:
+-


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does

Update GH PR templates to fit the needs of the new changelog system:
- Put in each PR the changelogs for this particular PR
- Once the PR is merged, update the CHANGELOGS files in the release branch