### PR TITLE
[O2B-750] File size is shown as '0' instead of null

### DIFF
--- a/lib/database/adapters/RunAdapter.js
+++ b/lib/database/adapters/RunAdapter.js
@@ -123,11 +123,11 @@ class RunAdapter {
             startOfDataTransfer: startOfDataTransfer ? new Date(startOfDataTransfer).getTime() : null,
             endOfDataTransfer: endOfDataTransfer ? new Date(endOfDataTransfer).getTime() : null,
             ctfFileCount,
-            ctfFileSize: ctfFileSize ? String(ctfFileSize) : null,
+            ctfFileSize: ctfFileSize !== null ? String(ctfFileSize) : null,
             tfFileCount,
-            tfFileSize: tfFileSize ? String(tfFileSize) : null,
+            tfFileSize: tfFileSize !== null ? String(tfFileSize) : null,
             otherFileCount,
-            otherFileSize: otherFileSize ? String(otherFileSize) : null,
+            otherFileSize: otherFileSize !== null ? String(otherFileSize) : null,
         };
         entityObject.runType = runType ? RunTypeAdapter.toEntity(runType) : runTypeId;
         entityObject.tags = tags ? tags.map(TagAdapter.toEntity) : [];

--- a/lib/database/seeders/20200713103855-runs.js
+++ b/lib/database/seeders/20200713103855-runs.js
@@ -105,6 +105,12 @@ module.exports = {
                         epn_topology: 'normal',
                         detectors: 'CPV',
                         trigger_value: 'OFF',
+                        ctf_file_count: 500,
+                        ctf_file_size: '0',
+                        tf_file_count: 30,
+                        tf_file_size: '0',
+                        other_file_count: 50,
+                        other_file_size: '0',
                     },
                     {
                         id: 4,

--- a/lib/public/components/RunDetail/index.js
+++ b/lib/public/components/RunDetail/index.js
@@ -190,7 +190,9 @@ const activeFields = (model) => ({
     ctfFileSize: {
         name: 'Ctf File Size',
         visible: true,
-        format: (fileSize) => fileSize ? `${fileSize} byte(s)` : '-',
+        format: (fileSize) => fileSize !== null
+            ? `${fileSize} byte(s)`
+            : '-',
     },
     tfFileCount: {
         name: 'Tf File Count',
@@ -199,7 +201,9 @@ const activeFields = (model) => ({
     tfFileSize: {
         name: 'Tf File Size',
         visible: true,
-        format: (size) => size ? `${size} byte(s)` : '-',
+        format: (fileSize) => fileSize !== null
+            ? `${fileSize} byte(s)`
+            : '-',
     },
     otherFileCount: {
         name: 'Other File Count',
@@ -208,7 +212,9 @@ const activeFields = (model) => ({
     otherFileSize: {
         name: 'Other File Size',
         visible: false,
-        format: (size) => size ? `${size} byte(s)` : '-',
+        format: (fileSize) => fileSize !== null
+            ? `${fileSize} byte(s)`
+            : '-',
     },
     eorReasons: {
         name: 'EOR Reasons',

--- a/test/e2e/runs.test.js
+++ b/test/e2e/runs.test.js
@@ -519,6 +519,25 @@ module.exports = () => {
                     done();
                 });
         });
+        it('should return 200 and values \'0\' for 0 file size values', (done) => {
+            request(server)
+                .get('/api/runs/3')
+                .expect(200)
+                .end((err, res) => {
+                    if (err) {
+                        done(err);
+                        return;
+                    }
+                    const { data } = res.body;
+                    // Response must satisfy the OpenAPI specification
+                    expect(res).to.satisfyApiSpec;
+
+                    expect(data.tfFileSize).to.equal('0');
+                    expect(data.otherFileSize).to.equal('0');
+                    expect(data.ctfFileSize).to.equal('0');
+                    done();
+                });
+        });
         it('should return 200 whenever there is only a trigger start', (done) => {
             request(server)
                 .get('/api/runs/104')


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [x] if it is a new feature, explain how you plan to use it
- [x] tests are added
- [x] documentation was updated or added

When requesting a run with tf/ctf/other file with the value of '0' the API would return null and show a - in the webpage. Now a '0' value is returned and shown in the details page