### PR TITLE
Fix issue in which notify does not have all information

### DIFF
--- a/lib/server/services/log/createLog.js
+++ b/lib/server/services/log/createLog.js
@@ -36,12 +36,12 @@ const notification = Notification.brokers ? new NotificationService(Notification
  */
 const notifyCreation = async (log) => {
     if (notification?.isConfigured() && log) {
-        const { id, tags, runs, title, author, text } = log;
+        const { id, tags, runs, title, user, text } = log;
         const url = `${HttpConfig.origin}?page=log-detail&id=${id}`;
         notification.send(
             tags.map((tag) => tag.text),
             title,
-            author.name,
+            user.name,
             url,
             runs.map(({ runNumber }) => runNumber),
             text,
@@ -119,7 +119,12 @@ exports.createLog = async (log, runNumbers, tagsTexts, attachments, transaction)
      * @return {Promise<void>} resolve once the notification has been sent
      */
     const notify = async () => {
-        const createdLog = await getLog(newLogId);
+        const createdLog = await getLog(newLogId, (queryBuilder) => {
+            queryBuilder
+                .include('user')
+                .include('tags')
+                .include('runs');
+        });
         if (createdLog !== null) {
             await notifyCreation(createdLog);
         }


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

PR which fixes 2 issues:
- updates new log create service to use the SequalizeUser parameter rather than the one from LogAdapter
- updates the query for the log to include tags and runs as well which are needed for notification service;

Notable changes for users:
- none

Notable changes for developers:
- updates new log create service to use the SequalizeUser parameter rather than the one from LogAdapter

Changes made to the database:
- none
