### PR TITLE
[O2B-779] Filter log on run number not run id

### DIFF
--- a/lib/database/repositories/LogRunsRepository.js
+++ b/lib/database/repositories/LogRunsRepository.js
@@ -43,14 +43,14 @@ class LogRunsRepository extends Repository {
 
         const groupedResult = result.reduce((accumulator, currentValue) => {
             if (accumulator[currentValue.logId]) {
-                accumulator[currentValue.logId].push(currentValue.runId);
+                accumulator[currentValue.logId].push(currentValue.run.runNumber);
             } else {
-                accumulator[currentValue.logId] = [currentValue.runId];
+                accumulator[currentValue.logId] = [currentValue.run.runNumber];
             }
             return accumulator;
         }, {});
 
-        return Object.entries(groupedResult).map(([key, value]) => ({ logId: key, runIds: value }));
+        return Object.entries(groupedResult).map(([key, value]) => ({ logId: key, runNumbers: value }));
     }
 
     /**

--- a/lib/database/tables/logruns.js
+++ b/lib/database/tables/logruns.js
@@ -25,5 +25,10 @@ module.exports = (sequelize) => {
 
     LogRuns.removeAttribute('id');
 
+    LogRuns.associate = (models) => {
+        LogRuns.belongsTo(models.Run, { foreignKey: 'runId', as: 'run' });
+        LogRuns.belongsTo(models.Log, { foreignKey: 'logId', as: 'log' });
+    };
+
     return LogRuns;
 };

--- a/lib/public/components/Filters/LogsFilter/runs.js
+++ b/lib/public/components/Filters/LogsFilter/runs.js
@@ -21,7 +21,7 @@ import { h } from '/js/src/index.js';
 const runsFilter = (logsModel) => h('input.w-75.mt1', {
     type: 'text',
     id: 'runsFilterText',
-    value: logsModel.getRunsFilter(),
+    value: logsModel.getRunsFilterRaw(),
     oninput: (e) => logsModel.setRunsFilter(e.target.value),
 }, '');
 

--- a/lib/public/views/Logs/Logs.js
+++ b/lib/public/views/Logs/Logs.js
@@ -240,6 +240,7 @@ export default class LogModel extends Observable {
 
         this.runFilterOperation = 'AND';
         this.runFilterValues = [];
+        this._runFilterRawValue = '';
 
         this._pagination.reset();
 
@@ -296,8 +297,8 @@ export default class LogModel extends Observable {
      * Returns the current title substring filter
      * @returns {String} The current title substring filter
      */
-    getRunsFilter() {
-        return this.runFilterValues;
+    getRunsFilterRaw() {
+        return this._runFilterRawValue;
     }
 
     /**
@@ -306,6 +307,7 @@ export default class LogModel extends Observable {
      * @returns {undefined}
      */
     setRunsFilter(runs) {
+        this._runFilterRawValue = runs;
         if (!/^[0-9,]*$/.test(runs)) {
             return;
         } else if (!runs.length) {

--- a/lib/usecases/log/GetAllLogsUseCase.js
+++ b/lib/usecases/log/GetAllLogsUseCase.js
@@ -27,6 +27,7 @@ const { getTagsByText } = require('../../server/services/tag/getTagsByText.js');
 const { groupByProperty } = require('../../database/utilities/groupByProperty.js');
 const { logAdapter } = require('../../database/adapters/index.js');
 const { ApiConfig } = require('../../config/index.js');
+const { Op } = require('sequelize');
 
 /**
  * GetAllLogsUseCase
@@ -141,7 +142,10 @@ class GetAllLogsUseCase {
 
             if (filter && filter.run) {
                 const runQueryBuilder = new QueryBuilder();
-                runQueryBuilder.where('runId').oneOf(...filter.run.values).orderBy('logId', 'asc');
+                runQueryBuilder.include({
+                    association: 'run',
+                    where: { runNumber: { [Op.in]: filter.run.values } },
+                }).orderBy('logId', 'asc');
 
                 let logRuns;
                 switch (filter.run.operation) {
@@ -149,7 +153,7 @@ class GetAllLogsUseCase {
                         logRuns = await LogRunsRepository
                             .findAllAndGroup(runQueryBuilder);
                         logRuns = logRuns
-                            .filter((logRun) => filter.run.values.every((runId) => logRun.runIds.includes(runId)));
+                            .filter((logRun) => filter.run.values.every((runNumber) => logRun.runNumbers.includes(runNumber)));
                         break;
                     case 'or':
                         logRuns = await LogRunsRepository

--- a/test/e2e/logs.test.js
+++ b/test/e2e/logs.test.js
@@ -109,6 +109,19 @@ module.exports = () => {
                 });
         });
 
+        it('should successfully filter by run number', async () => {
+            const response = await request(server).get('/api/logs?filter[run][values]=1,2&filter[run][operation]=and');
+            expect(response.status).to.equal(200);
+
+            expect(response.body.data).to.be.an('array');
+            // 3 logs created in public tests
+            expect(response.body.data).to.lengthOf(6);
+            for (const log of response.body.data) {
+                const relatedRunNumbers = log.runs.map(({ runNumber }) => runNumber);
+                expect([1, 2].every((runNumber) => relatedRunNumbers.includes(runNumber))).to.be.true;
+            }
+        });
+
         it('should return 400 if the author filter is left empty', (done) => {
             request(server)
                 .get('/api/logs?filter[author]= ')
@@ -280,7 +293,7 @@ module.exports = () => {
                     expect(res.body.data).to.be.an('array');
                     expect(res.body.data
                         .every((log) => log.tags.length > 0 && log.tags.some((tag) => tag.id === 2)
-                        && log.tags.some((tag) => tag.id === 5)))
+                            && log.tags.some((tag) => tag.id === 5)))
                         .to.be.true;
 
                     done();

--- a/test/public/defaults.js
+++ b/test/public/defaults.js
@@ -102,6 +102,21 @@ module.exports.reloadPage = (page) => page.reload({ waitUntil: 'networkidle0' })
 module.exports.goToPage = (page, pageText) => page.goto(`${getUrl()}/?page=${pageText}`, { waitUntil: 'networkidle0' });
 
 /**
+ * Wait for page network idle and add a small timeout to let the page redraw
+ *
+ * @param {Object} page the puppeteer page object
+ * @param {Object} [options] eventual options
+ * @param {number} [options.redrawDuration] duration of the page redraw (in ms)
+ * @return {Promise<void>} resolves once the page is fully redraw
+ */
+module.exports.waitForNetworkIdleAndRedraw = async (page, options) => {
+    const { redrawDuration = 20 } = options ?? {};
+
+    await page.waitForNetworkIdle();
+    await page.waitForTimeout(redrawDuration);
+};
+
+/**
  * Validates if selector is present and returns the element.
  * @param {Object} page Puppeteer page object.
  * @param {String} selector Css selector.

--- a/test/public/runs/detail.test.js
+++ b/test/public/runs/detail.test.js
@@ -13,7 +13,7 @@
 
 const chai = require('chai');
 const { defaultBefore, defaultAfter, expectInnerText, pressElement, getFirstRow } = require('../defaults');
-const { reloadPage, takeScreenshot } = require('../defaults.js');
+const { reloadPage } = require('../defaults.js');
 
 const { expect } = chai;
 
@@ -85,7 +85,6 @@ module.exports = () => {
         await page.waitForTimeout(100);
         const goodQualityRadioSelector = '#detector-quality-1-good';
         const badQualityRadioSelector = '#detector-quality-1-bad';
-        await takeScreenshot(page);
         expect(await page.$eval(goodQualityRadioSelector, (element) => element.checked)).to.be.true;
         expect(await page.$eval(badQualityRadioSelector, (element) => element.checked)).to.be.false;
         await pressElement(page, badQualityRadioSelector);

--- a/test/usecases/log/GetAllLogsUseCase.test.js
+++ b/test/usecases/log/GetAllLogsUseCase.test.js
@@ -71,6 +71,31 @@ module.exports = () => {
         expect(filteredResult.count).to.equal(rootLog.replies);
     });
 
+    it('should successfully filter on run numbers', async () => {
+        const runNumbers = [1, 2];
+        getAllLogsDto.query = { filter: { run: { operation: 'and', values: runNumbers } } };
+
+        {
+            const { logs: filteredResult } = await new GetAllLogsUseCase().execute(getAllLogsDto);
+            expect(filteredResult).to.lengthOf(3);
+            for (const log of filteredResult) {
+                const relatedRunNumbers = log.runs.map(({ runNumber }) => runNumber);
+                expect(runNumbers.every((runNumber) => relatedRunNumbers.includes(runNumber))).to.be.true;
+            }
+        }
+
+        getAllLogsDto.query = { filter: { run: { operation: 'or', values: runNumbers } } };
+
+        {
+            const { logs: filteredResult } = await new GetAllLogsUseCase().execute(getAllLogsDto);
+            expect(filteredResult).to.lengthOf(6);
+            for (const log of filteredResult) {
+                const relatedRunNumbers = log.runs.map(({ runNumber }) => runNumber);
+                expect(runNumbers.some((runNumber) => relatedRunNumbers.includes(runNumber))).to.be.true;
+            }
+        }
+    });
+
     it('should return a count that is the same as the count method of the repository', async () => {
         const expectedCount = await LogRepository.count();
 


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [ ] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- Log runs filter applies on run number and not on run ID anymore