### PR TITLE
[O2B-794] Sort detectors in run filtering

### DIFF
--- a/lib/server/services/detector/DetectorService.js
+++ b/lib/server/services/detector/DetectorService.js
@@ -18,12 +18,12 @@ const { detectorAdapter } = require('../../../database/adapters/index.js');
  */
 class DetectorService {
     /**
-     * Return the full list of all the available detectors
+     * Return the full list of all the available detectors sorted alphabetically
      *
      * @return {Promise<Detector[]>} all the available detectors
      */
     async getAll() {
-        return (await getAllDetectors()).map(detectorAdapter.toEntity);
+        return (await getAllDetectors((queryBuilder) => queryBuilder.orderBy('name', 'ASC'))).map(detectorAdapter.toEntity);
     }
 }
 

--- a/lib/server/services/detector/getAllDetectors.js
+++ b/lib/server/services/detector/getAllDetectors.js
@@ -12,10 +12,19 @@
  */
 
 const { repositories: { DetectorRepository } } = require('../../../database');
+const { utilities: { QueryBuilder } } = require('../../../database');
 
 /**
  * Return the list of all the available detectors
  *
- * @returns {Promise<SequelizeDetector[]>} Promise resolving with the list of tags
+ * @param {function|null} qbConfiguration function called with the detectors query builder as parameter to add specific configuration to the
+ *     query
+ * @returns {Promise<SequelizeDetector[]>} Promise resolving with the list of detectors
  */
-exports.getAllDetectors = () => DetectorRepository.findAll();
+exports.getAllDetectors = (qbConfiguration = null) => {
+    const queryBuilder = new QueryBuilder();
+    if (qbConfiguration) {
+        qbConfiguration(queryBuilder);
+    }
+    return DetectorRepository.findAll(queryBuilder);
+};

--- a/lib/server/services/run/getRun.js
+++ b/lib/server/services/run/getRun.js
@@ -24,7 +24,7 @@ const RunRepository = require('../../../database/repositories/RunRepository.js')
  * @param {Object} [transaction] optionally the transaction in which one the log creation is executed
  * @return {Promise<SequelizeRun|null>} the run found or null
  */
-exports.getRun = async ({ runId, runNumber }, qbConfiguration = null, transaction = null) => {
+exports.getRun = ({ runId, runNumber }, qbConfiguration = null, transaction = null) => {
     const queryBuilder = new QueryBuilder();
 
     if (runNumber) {
@@ -38,7 +38,5 @@ exports.getRun = async ({ runId, runNumber }, qbConfiguration = null, transactio
     if (qbConfiguration) {
         qbConfiguration(queryBuilder);
     }
-    const run = await TransactionHelper.provide(async () =>
-        RunRepository.findOne(queryBuilder), { transaction });
-    return run;
+    return TransactionHelper.provide(async () => RunRepository.findOne(queryBuilder), { transaction });
 };

--- a/test/e2e/detectors.test.js
+++ b/test/e2e/detectors.test.js
@@ -25,9 +25,12 @@ module.exports = () => {
             expect(response.status).to.equal(200);
             expect(response.body).to.be.an('object');
             expect(response.body.data.map(({ id, name }) => ({ id, name }))).to.deep.eq([
+                { id: 17, name: 'ACO' },
                 { id: 1, name: 'CPV' },
+                { id: 18, name: 'CTP' },
                 { id: 2, name: 'EMC' },
                 { id: 3, name: 'FDD' },
+                { id: 19, name: 'FIT' },
                 { id: 4, name: 'FT0' },
                 { id: 5, name: 'FV0' },
                 { id: 6, name: 'HMP' },
@@ -41,9 +44,6 @@ module.exports = () => {
                 { id: 14, name: 'TRD' },
                 { id: 15, name: 'TST' },
                 { id: 16, name: 'ZDC' },
-                { id: 17, name: 'ACO' },
-                { id: 18, name: 'CTP' },
-                { id: 19, name: 'FIT' },
             ]);
         });
     });

--- a/test/server/services/detector/DetectorService.test.js
+++ b/test/server/services/detector/DetectorService.test.js
@@ -15,12 +15,15 @@ const { detectorService } = require('../../../../lib/server/services/detector/De
 const { expect } = require('chai');
 
 module.exports = () => {
-    it('should successfully return the full list of detectors', async () => {
+    it('should successfully return the full list of detectors sorted alphabetically', async () => {
         const detectors = await detectorService.getAll();
         expect(detectors.map(({ id, name }) => ({ id, name }))).to.deep.eq([
+            { id: 17, name: 'ACO' },
             { id: 1, name: 'CPV' },
+            { id: 18, name: 'CTP' },
             { id: 2, name: 'EMC' },
             { id: 3, name: 'FDD' },
+            { id: 19, name: 'FIT' },
             { id: 4, name: 'FT0' },
             { id: 5, name: 'FV0' },
             { id: 6, name: 'HMP' },
@@ -34,9 +37,6 @@ module.exports = () => {
             { id: 14, name: 'TRD' },
             { id: 15, name: 'TST' },
             { id: 16, name: 'ZDC' },
-            { id: 17, name: 'ACO' },
-            { id: 18, name: 'CTP' },
-            { id: 19, name: 'FIT' },
         ]);
     });
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- Detectors are now sorted in the run's detector filter