### PR TITLE
[O2B-812] Bump docker nodejs base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #
 # ---- Base ----
-FROM node:16.16.0-alpine3.16 as base
+FROM node:16.19.0-alpine3.16 as base
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for developers:
- Bumped version of nodejs base image from `node:16.16.0-alpine3.16` to `node:16.19.0-alpine3.16`