### PR TITLE
[O2B-766] Add log-id and parent-log-id to kafka message

### DIFF
--- a/lib/server/services/log/createLog.js
+++ b/lib/server/services/log/createLog.js
@@ -35,17 +35,25 @@ const notification = Notification.brokers ? new NotificationService(Notification
  * @private
  */
 const notifyCreation = async (log) => {
-    if (notification?.isConfigured() && log) {
-        const { id, tags, runs, title, user, text } = log;
+    const { id, parentLogId, tags, runs, title, user, text } = log;
+
+    if (notification?.isConfigured() && tags.length > 0 && title) {
+        const tagsAsString = tags.map((tag) => tag.text).join(',');
+        const runNumbers = runs.map(({ runNumber }) => runNumber);
         const url = `${HttpConfig.origin}?page=log-detail&id=${id}`;
-        notification.send(
-            tags.map((tag) => tag.text),
+
+        const message = {
+            id,
+            parentLogId,
             title,
-            user?.name ?? 'Anonymous',
+            tag: tagsAsString,
+            author: user?.name ?? 'Anonymous',
             url,
-            runs.map(({ runNumber }) => runNumber),
-            text,
-        );
+            runNumbers: runNumbers.length > 0 ? runNumbers.join(',') : undefined,
+            extra: text,
+        };
+
+        notification.send(message);
     }
 };
 

--- a/lib/server/services/log/createLog.js
+++ b/lib/server/services/log/createLog.js
@@ -38,17 +38,15 @@ const notifyCreation = async (log) => {
     const { id, parentLogId, tags, runs, title, user, text } = log;
 
     if (notification?.isConfigured() && tags.length > 0 && title) {
-        const tagsAsString = tags.map((tag) => tag.text).join(',');
         const runNumbers = runs.map(({ runNumber }) => runNumber);
-        const url = `${HttpConfig.origin}?page=log-detail&id=${id}`;
 
         const message = {
             id,
             parentLogId,
             title,
-            tag: tagsAsString,
+            tag: tags.map((tag) => tag.text).join(','),
             author: user?.name ?? 'Anonymous',
-            url,
+            url: `${HttpConfig.origin}?page=log-detail&id=${id}`,
             runNumbers: runNumbers.length > 0 ? runNumbers.join(',') : undefined,
             extra: text,
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "umzug"
       ],
       "dependencies": {
-        "@aliceo2/web-ui": "2.1.0",
+        "@aliceo2/web-ui": "2.2.0",
         "@grpc/grpc-js": "1.8.3",
         "@grpc/proto-loader": "0.7.0",
         "cls-hooked": "4.2.2",
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@aliceo2/web-ui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@aliceo2/web-ui/-/web-ui-2.1.0.tgz",
-      "integrity": "sha512-2asXplgFXk6jXUY7oY+SMN3DdrW5kNYvEdyRooT7hUBYlcRdmsGxrFwCcmprsNQ+X07XJwePhFW0Vi6PjugnOA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@aliceo2/web-ui/-/web-ui-2.2.0.tgz",
+      "integrity": "sha512-UMJq6EggpmMom23DDFHeukrSm142HVhR8GWgLAbKE39z+p0WLtlGEkVbibfsUYhHpjXZRlkPNoA3pQMjWS4QgQ==",
       "inBundle": true,
       "dependencies": {
         "express": "^4.18.0",
@@ -6447,9 +6447,9 @@
   },
   "dependencies": {
     "@aliceo2/web-ui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@aliceo2/web-ui/-/web-ui-2.1.0.tgz",
-      "integrity": "sha512-2asXplgFXk6jXUY7oY+SMN3DdrW5kNYvEdyRooT7hUBYlcRdmsGxrFwCcmprsNQ+X07XJwePhFW0Vi6PjugnOA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@aliceo2/web-ui/-/web-ui-2.2.0.tgz",
+      "integrity": "sha512-UMJq6EggpmMom23DDFHeukrSm142HVhR8GWgLAbKE39z+p0WLtlGEkVbibfsUYhHpjXZRlkPNoA3pQMjWS4QgQ==",
       "requires": {
         "express": "^4.18.0",
         "helmet": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docker-test": "docker-compose -p test -f docker-compose.yml -p test -f docker-compose.test.yml up --build --abort-on-container-exit"
   },
   "dependencies": {
-    "@aliceo2/web-ui": "2.1.0",
+    "@aliceo2/web-ui": "2.2.0",
     "@grpc/grpc-js": "1.8.3",
     "@grpc/proto-loader": "0.7.0",
     "cls-hooked": "4.2.2",


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users: NA

Notable changes for developers:
- NotifcationService `send` method, now expects a general message without project specific fields. The message is built on BKP side
- Existing message field criteria was taken from: https://github.com/AliceO2Group/WebUi/pull/1796/files#diff-c025c39557c4ea200883fe9f312aff9ebc69528d9c724c71a452fc6e7c8bf826L77

Changes made to the database: NA