### PR TITLE
[O2B-842] Add NOISE as run type for CALIBRATION run definition

### DIFF
--- a/docs/RUN_DEFINITIONS.md
+++ b/docs/RUN_DEFINITIONS.md
@@ -46,7 +46,7 @@ During synthetic runs, the processes are at the level of readout and emulate rea
 - `trigger_value` = `OFF`
 
 ### CALIBRATION:
-- `run_type` should be prefixed with `CALIBRATION_`, `PEDESTAL`, `LASER`, `PULSER`
+- `run_type` should be prefixed with `CALIBRATION_`, `PEDESTAL`, `LASER`, `PULSER`, `NOISE`
 
 ### COMMISIONING:
 - any run that does not fit any of the prior definitions;

--- a/lib/server/services/run/getRunDefinition.js
+++ b/lib/server/services/run/getRunDefinition.js
@@ -22,7 +22,7 @@ const RunDefinition = {
 
 const COSMICS_OR_PHYSICS_TF_BUILDER_MODE = ['processing', 'processing-disk'];
 
-const CALIBRATION_RUN_TYPES_STARTS_WITH = ['CALIBRATION_', 'PEDESTAL', 'LASER', 'PULSER'];
+const CALIBRATION_RUN_TYPES_STARTS_WITH = ['CALIBRATION_', 'PEDESTAL', 'LASER', 'PULSER', 'NOISE'];
 
 /**
  * Returns the definition of a given run

--- a/test/lib/server/services/run/getRunDefinition.test.js
+++ b/test/lib/server/services/run/getRunDefinition.test.js
@@ -46,5 +46,6 @@ module.exports = () => {
         expect(getRunDefinition(CALIBRATION.PEDESTAL)).to.equal(RunDefinition.Calibration);
         expect(getRunDefinition(CALIBRATION.LASER)).to.equal(RunDefinition.Calibration);
         expect(getRunDefinition(CALIBRATION.PULSER)).to.equal(RunDefinition.Calibration);
+        expect(getRunDefinition(CALIBRATION.NOISE)).to.equal(RunDefinition.Calibration);
     });
 };

--- a/test/mocks/mock-run.js
+++ b/test/mocks/mock-run.js
@@ -267,5 +267,24 @@ module.exports = {
                 name: 'PULSER',
             },
         },
+        NOISE: {
+            dcs: false,
+            dd_flp: true,
+            epn: true,
+            triggerValue: 'OFF',
+            tfbDdMode: 'processing',
+            pdpWorkflowParameters: 'QC,CTF',
+            readoutCfgUri: 'reply/pbpb',
+            lhcFill: {
+                stableBeamsStart: '2022-10-01T10:00:00',
+                stableBeamsEnd: '2022-10-02T10:00:00',
+            },
+            startTime: 1664618400000, // 2022-10-01T12:00:00
+            endTime: 1664625600000, // 2022-10-01T14:00:00
+            concatenatedDetectors: 'TPC, TST',
+            runType: {
+                name: 'NOISE',
+            },
+        },
     },
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- `CALIBRATION` definition will now look for `NOISE` as runType as well

Notable changes for developers:
-

Changes made to the database:
-
