### PR TITLE
[O2B-840] Filter logs in shift's environments

### DIFF
--- a/lib/server/services/eosReport/EosReportService.js
+++ b/lib/server/services/eosReport/EosReportService.js
@@ -17,7 +17,7 @@ const { getShiftFromTimestamp } = require('../shift/getShiftFromTimestamp.js');
 const { logService } = require('../log/LogService.js');
 const { getShiftIssues } = require('./getShiftIssues.js');
 const { shiftService } = require('../shift/ShiftService.js');
-const { getEnvironmentsInPeriod } = require('../environment/getEnvironmentsInPeriod.js');
+const { getShiftEnvironments } = require('../shift/getShiftEnvironments.js');
 
 /**
  * @typedef Shift
@@ -114,10 +114,7 @@ class EosReportService {
  * @return {EcsEosReportTypeSpecific} the ecs EOS report type specific
  */
 const getEcsSpecificReportData = async (shift) => ({
-    environments: await getEnvironmentsInPeriod(
-        { from: shift.start, to: shift.end },
-        { runs: { relations: { lhcFill: true, eorReasons: true, logs: true } } },
-    ),
+    environments: await getShiftEnvironments(shift),
 });
 
 exports.EosReportService = EosReportService;

--- a/lib/server/services/eosReport/eosTypeSpecificFormatter/formatEcsEosReportTypeSpecific.js
+++ b/lib/server/services/eosReport/eosTypeSpecificFormatter/formatEcsEosReportTypeSpecific.js
@@ -14,8 +14,6 @@
 const { getRunDefinition } = require('../../run/getRunDefinition.js');
 const { frontUrl } = require('../../../../utilities/frontUrl.js');
 
-const ECS_EOR_REPORT_RUNS_LOGS_REQUIRED_TAGS = ['ECS', 'ECS Shifter'];
-
 /**
  * Returns the ECS specific part of a given EOS report
  *
@@ -35,7 +33,7 @@ exports.formatEcsEosReportTypeSpecific = async ({ environments }) => formatEcsSp
 const formatEnvironment = (environment) => {
     let ret = `- (${environment.createdAt.getTime()}) [${environment.id}](${frontUrl({ page: 'env-details', environmentId: environment.id })})`;
     if (environment.runs.length > 0) {
-        ret += `\n${environment.runs.map((run) => formatRun(run, filterLogs(run.logs))).join('\n')}`;
+        ret += `\n${environment.runs.map((run) => formatRun(run)).join('\n')}`;
     }
     return ret;
 };
@@ -44,17 +42,16 @@ const formatEnvironment = (environment) => {
  * Format the given run to be displayed in the ECS EOS report
  *
  * @param {SequelizeRun} run the run to format
- * @param {SequelizeLog[]} filteredLogs the run's filtered logs
  * @return {string} the formatted run
  */
-const formatRun = (run, filteredLogs) => {
+const formatRun = (run) => {
     let ret = `    * (${run.timeTrgStart?.getTime() ?? run.timeO2Start?.getTime() ?? '-'})`
         + ` [${run.runNumber}](${frontUrl({ page: 'run-detail', id: run.id })}) - ${getRunDefinition(run)} - ${run.runQuality}`;
     if (run.eorReasons.length > 0) {
         ret += `\n        - EOR:\n${run.eorReasons.map(formatEorReason).join('\n')}`;
     }
-    if (filteredLogs.length > 0) {
-        ret += `\n        - Logs:\n${filteredLogs.map(formatLog).join('\n')}`;
+    if (run.logs.length > 0) {
+        ret += `\n        - Logs:\n${run.logs.map(formatLog).join('\n')}`;
     }
     return ret;
 };
@@ -72,20 +69,6 @@ const formatEorReason = ({ reasonType, description }) => {
     }
     ret += ` - ${description}`;
     return ret;
-};
-
-/**
- * Filter the runs logs to be displayed in the report
- *
- * @param {SequelizeLog[]|undefined|null} [logs] the logs to display
- * @return {SequelizeLog[]} the filtered logs
- */
-const filterLogs = (logs) => {
-    if (!logs?.length) {
-        return [];
-    }
-
-    return logs.filter(({ tags }) => tags.some(({ text }) => ECS_EOR_REPORT_RUNS_LOGS_REQUIRED_TAGS.includes(text)));
 };
 
 /**

--- a/lib/server/services/shift/getShiftEnvironments.js
+++ b/lib/server/services/shift/getShiftEnvironments.js
@@ -1,0 +1,36 @@
+/**
+ *  @license
+ *  Copyright CERN and copyright holders of ALICE O2. This software is
+ *  distributed under the terms of the GNU General Public License v3 (GPL
+ *  Version 3), copied verbatim in the file "COPYING".
+ *
+ *  See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ *  In applying this license CERN does not waive the privileges and immunities
+ *  granted to it by virtue of its status as an Intergovernmental Organization
+ *  or submit itself to any jurisdiction.
+ */
+
+const { getEnvironmentsInPeriod } = require('../environment/getEnvironmentsInPeriod.js');
+
+const ECS_EOR_REPORT_RUNS_LOGS_REQUIRED_TAGS = ['ECS', 'ECS Shifter'];
+
+/**
+ * Returns the environments related to a given shift with pre-defined relations
+ *
+ * @param {Shift} shift the shift for which environments must be retrieved
+ * @return {Promise<SequelizeEnvironment[]>} the list of environments
+ */
+exports.getShiftEnvironments = async (shift) => {
+    const environments = await getEnvironmentsInPeriod(
+        { from: shift.start, to: shift.end },
+        { runs: { relations: { lhcFill: true, eorReasons: true, logs: true } } },
+    );
+    // Not able to filter logs in one pass, because we need to restrict them on their tags BUT fetch all of their tags
+    for (const environment of environments) {
+        for (const run of environment.runs) {
+            run.logs = run.logs.filter(({ tags }) => tags.some(({ text }) => ECS_EOR_REPORT_RUNS_LOGS_REQUIRED_TAGS.includes(text)));
+        }
+    }
+    return environments;
+};

--- a/test/mocks/mock-eos-report.js
+++ b/test/mocks/mock-eos-report.js
@@ -76,7 +76,19 @@ const customizedECSEorReport = {
                                 description: '2nd EOR description',
                             },
                         ],
-                        logs: customizedEcsEorReportLogs,
+                        logs: [
+                            {
+                                id: 120,
+                                title: 'Third issue log',
+                                tags: [{ text: 'ECS' }],
+                                user: { id: 1 },
+                            },
+                            {
+                                id: 124,
+                                title: 'Fifth issue log',
+                                tags: [{ text: 'ECS Shifter' }],
+                            },
+                        ],
                     },
                 ],
             },


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [ ] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for developers:
- ECS EoS report logs are filtered in environments list and not in the formatting function anymore
