### PR TITLE
[O2B-841] Remove EOS report link from logs pages

### DIFF
--- a/lib/public/views/Logs/Overview/index.js
+++ b/lib/public/views/Logs/Overview/index.js
@@ -68,9 +68,6 @@ const showLogsTable = (model, logs) => {
  *
  * @returns {vnode} A button which will redirect to creation of logs
  */
-const actionButtons = () => h('.flex-row.g3', [
-    frontLink('EOS report', 'eos-report-create', null, { class: 'btn btn-primary h2' }),
-    frontLink('Add Log Entry', 'log-create', null, { class: 'btn btn-primary h2' }),
-]);
+const actionButtons = () => h('.flex-row.g3', [frontLink('Add Log Entry', 'log-create', null, { class: 'btn btn-primary h2' })]);
 
 export default (model) => logOverviewScreen(model);


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [ ] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- The EOS report button is not available on log display
