### PR TITLE
[O2B-853] Use current user as EoS report log author

### DIFF
--- a/lib/server/services/eosReport/EosReportService.js
+++ b/lib/server/services/eosReport/EosReportService.js
@@ -108,6 +108,7 @@ class EosReportService {
 
         return logService.create(
             {
+                userId: shifter.id,
                 title: report.substring(2, report.indexOf('\n')),
                 text: report,
                 subtype: 'comment',

--- a/test/lib/server/services/eosReport/EosReportService.test.js
+++ b/test/lib/server/services/eosReport/EosReportService.test.js
@@ -87,6 +87,7 @@ module.exports = () => {
         expect(log.title).to.equal(eosReportTitle);
         expect(log.tags.map(({ text }) => text)).to.have.members(getEosReportTagsByType(ShiftTypes.ECS));
         expect(log.runs.map(({ runNumber }) => runNumber)).to.eql(expectedRunNumbers);
+        expect(log.author.id).to.equal(1);
     });
 
     it('should successfully create a log containing EOS report with default values', async () => {
@@ -96,5 +97,6 @@ module.exports = () => {
         expect(log.text).to.equal(formattedEmptyECSEorReport);
         expect(log.title).to.equal(eosReportTitle);
         expect(log.runs.length).to.equal(0);
+        expect(log.author.id).to.equal(1);
     });
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- The current user is used as author of EoS report log
