### PR TITLE
[O2B-856] Update EoS report cutoff from 2h to 30min

### DIFF
--- a/lib/server/services/shift/ShiftService.js
+++ b/lib/server/services/shift/ShiftService.js
@@ -18,8 +18,8 @@ const { ShiftTypes } = require('../../../domain/enums/ShiftTypes.js');
 const { getShiftEnvironments } = require('./getShiftEnvironments.js');
 const { getShiftTagsFiltersByType } = require('./getShiftTagsFiltersByType.js');
 
-// Time after the end of the shift during which one the user is allowed to fill the EOS report
-const PENDING_SHIFT_MARGIN = 2 * 3600 * 1000;
+// Time after the end of the shift during which one the user is allowed to fill the EOS report (currently 30 minutes)
+const PENDING_SHIFT_MARGIN = 30 * 60 * 1000;
 
 /**
  * Service to generate end of shift report


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- The time to fill EoS report after the end of shift is now 30min (previously 2h)
