### PR TITLE
[O2B-861] Fix data reset when clicking in EoS report's shifter-name input

### DIFF
--- a/lib/public/components/common/markdown/markdown.js
+++ b/lib/public/components/common/markdown/markdown.js
@@ -35,6 +35,9 @@ export const markdownInput = (content, attributes, onEditorChange, size) => {
     onEditorChange = onEditorChange || (() => {
     });
 
+    const onInput = attributes.oninput || attributes.onchange || (() => {
+    });
+
     return h(
         '.flex-grow',
         h(
@@ -46,7 +49,7 @@ export const markdownInput = (content, attributes, onEditorChange, size) => {
                     cleanCodeMirror(this.textarea);
                     onEditorChange(markdownInputFromTextarea(
                         node.dom,
-                        (value) => attributes.onchange({ target: { value } }),
+                        (value) => onInput({ target: { value } }),
                         size,
                     ));
                     this.textarea = node.dom;
@@ -97,11 +100,11 @@ export const markdownDisplay = (content, attributes, size) => h(
  * Extract a markdown editor form an existing textarea
  *
  * @param {HTMLTextAreaElement} textarea the textarea from which markdown component must be extracted
- * @param {function} onChange function called any time the markdown content changes
+ * @param {function} onInput function called any time the markdown content changes
  * @param {Partial<MarkdownBoxSize>} size the size of the markdown input
  * @return {vnode} the component
  */
-const markdownInputFromTextarea = (textarea, onChange, size) => {
+const markdownInputFromTextarea = (textarea, onInput, size) => {
     const editor = markdownFromTextarea(textarea, false, size);
 
     editor.on('inputRead', (_cm, change) => {
@@ -110,8 +113,8 @@ const markdownInputFromTextarea = (textarea, onChange, size) => {
         }
     });
 
-    if (onChange) {
-        editor.on('change', (cm) => onChange(cm.getValue()));
+    if (onInput) {
+        editor.on('change', (cm) => onInput(cm.getValue()));
     }
     return editor;
 };

--- a/lib/public/views/EosReport/create/eosReportCreationComponent.js
+++ b/lib/public/views/EosReport/create/eosReportCreationComponent.js
@@ -34,7 +34,7 @@ const eosReportCreationForm = (formData, shiftData) => [
                 h('input.form-control', {
                     value: formData.shifterName,
                     // eslint-disable-next-line no-return-assign
-                    onchange: (e) => formData.shifterName = e.target.value,
+                    oninput: (e) => formData.shifterName = e.target.value,
                 }),
             ]),
             h('#trainee-name.panel.flex-grow', [
@@ -42,7 +42,7 @@ const eosReportCreationForm = (formData, shiftData) => [
                 h('input.form-control', {
                     value: formData.traineeName,
                     // eslint-disable-next-line no-return-assign
-                    onchange: (e) => formData.traineeName = e.target.value,
+                    oninput: (e) => formData.traineeName = e.target.value,
                 }),
             ]),
         ]),
@@ -69,7 +69,7 @@ const eosReportCreationForm = (formData, shiftData) => [
                 formData.lhcTransitions,
                 {
                     // eslint-disable-next-line no-return-assign
-                    onchange: (e) => formData.lhcTransitions = e.target.value,
+                    oninput: (e) => formData.lhcTransitions = e.target.value,
                 },
                 null,
                 { height: '20rem' },
@@ -81,7 +81,7 @@ const eosReportCreationForm = (formData, shiftData) => [
                 formData.shiftFlow,
                 {
                     // eslint-disable-next-line no-return-assign
-                    onchange: (e) => formData.shiftFlow = e.target.value,
+                    oninput: (e) => formData.shiftFlow = e.target.value,
                 },
                 null,
                 { height: '20rem' },
@@ -95,7 +95,7 @@ const eosReportCreationForm = (formData, shiftData) => [
                 formData.infoFromPreviousShifter,
                 {
                     // eslint-disable-next-line no-return-assign
-                    onchange: (e) => formData.infoFromPreviousShifter = e.target.value,
+                    oninput: (e) => formData.infoFromPreviousShifter = e.target.value,
                 },
                 null,
                 { height: '10rem' },
@@ -107,7 +107,7 @@ const eosReportCreationForm = (formData, shiftData) => [
                 formData.infoForNextShifter,
                 {
                     // eslint-disable-next-line no-return-assign
-                    onchange: (e) => formData.infoForNextShifter = e.target.value,
+                    oninput: (e) => formData.infoForNextShifter = e.target.value,
                 },
                 null,
                 { height: '10rem' },
@@ -118,8 +118,8 @@ const eosReportCreationForm = (formData, shiftData) => [
             markdownInput(
                 formData.infoForRmRc,
                 {
-                    // eslint-disable-next-line no-return-assign
-                    onchange: (e) => formData.infoForRmRc = e.target.value,
+                // eslint-disable-next-line no-return-assign
+                    oninput: (e) => formData.infoForRmRc = e.target.value,
                 },
                 null,
                 { height: '10rem' },

--- a/lib/public/views/Logs/Create/logCreationComponent.js
+++ b/lib/public/views/Logs/Create/logCreationComponent.js
@@ -133,9 +133,8 @@ const markdownTextArea = (logCreationModel) => labeledInput(
         {
             id: 'text',
             placeholder: 'Your message...',
-            onchange: (e) => {
-                logCreationModel.text = e.target.value;
-            },
+            // eslint-disable-next-line no-return-assign
+            oninput: (e) => logCreationModel.text = e.target.value,
         },
         (editor) => {
             logCreationModel.textEditor = editor;

--- a/test/public/eosReport/creation.test.js
+++ b/test/public/eosReport/creation.test.js
@@ -88,7 +88,7 @@ module.exports = () => {
         await page.waitForSelector('#shifter-name input');
         expect(await page.$eval('#shifter-name input', (input) => input.value)).to.equal('Anonymous');
         await page.focus('#shifter-name input');
-        await fillInput(page, '#shifter-name input', 'Shifter name', ['change']);
+        await fillInput(page, '#shifter-name input', 'Shifter name');
 
         await page.waitForSelector('#trainee-name input');
         await page.focus('#trainee-name input');


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- Fixed bug which reseted the input data of EoS report's shifter name when clicking in it while it is focused
