### PR TITLE
[O2B-864] Fix LHC fill infinite scroll

### DIFF
--- a/lib/public/components/Pagination/PaginationModel.js
+++ b/lib/public/components/Pagination/PaginationModel.js
@@ -14,7 +14,6 @@ import { Observable } from '/js/src/index.js';
 
 const DEFAULT_ITEMS_PER_PAGE = 10;
 const DEFAULT_CURRENT_PAGE = 1;
-const DEFAULT_TOTAL_PAGES_COUNT = 1;
 const DEFAULT_ITEMS_COUNT = 0;
 const ENABLE_INFINITE_MODE_BY_DEFAULT = false;
 
@@ -35,7 +34,6 @@ export class PaginationModel extends Observable {
         this._itemsPerPage = null;
         this._customItemsPerPage = '';
         this._currentPage = DEFAULT_CURRENT_PAGE;
-        this._pagesCount = DEFAULT_TOTAL_PAGES_COUNT;
         this._itemsCount = DEFAULT_ITEMS_COUNT;
         this._isInfiniteScrollEnabled = ENABLE_INFINITE_MODE_BY_DEFAULT;
 
@@ -52,7 +50,6 @@ export class PaginationModel extends Observable {
         this._defaultItemsPerPage = null;
         this._customItemsPerPage = '';
         this._currentPage = DEFAULT_CURRENT_PAGE;
-        this._pagesCount = DEFAULT_TOTAL_PAGES_COUNT;
         this._isInfiniteScrollEnabled = ENABLE_INFINITE_MODE_BY_DEFAULT;
     }
 

--- a/lib/public/views/LhcFills/Overview/LhcFillsOverviewModel.js
+++ b/lib/public/views/LhcFills/Overview/LhcFillsOverviewModel.js
@@ -51,12 +51,11 @@ export class LhcFillsOverviewModel extends Observable {
      * @return {Promise<void>} void
      */
     async fetchAllLhcFills() {
-        /**
-         * @type {LhcFill[]}
+        /*
+         * When fetching data, to avoid concurrency issues, save a flag stating if the fetched data should be concatenated with the current one
+         * (infinite scroll) or if they should replace them
          */
-        const concatenateWith = this._pagination.currentPage > 1 && this._pagination.isInfiniteScrollEnabled
-            ? this._lhcFills.payload || []
-            : [];
+        const keepExisting = this._pagination.currentPage > 1 && this._pagination.isInfiniteScrollEnabled;
 
         if (!this._pagination.isInfiniteScrollEnabled) {
             this._lhcFills = RemoteData.loading();
@@ -72,6 +71,7 @@ export class LhcFillsOverviewModel extends Observable {
 
         try {
             const { items, totalCount } = await getRemoteDataSlice(endpoint);
+            const concatenateWith = keepExisting ? this._lhcFills.payload || [] : [];
             this._lhcFills = RemoteData.success([...concatenateWith, ...items]);
             for (const item of items) {
                 addStatisticsToLhcFill(item);


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

This commit is only a simple patch, the infinite scroll is flawed and do not handle at all the concurrency issues.
Data fetching should be separated from display.

This patch is only applied on LHC fill, other similar pages stay the same. This code should be factorized between all overview pages.

Notable changes for users:
- LHC fill overview infinite scroll now display valid data
