### PR TITLE
[O2B-878] Use new headless chrome for puppeteer tests

### DIFF
--- a/test/public/defaults.js
+++ b/test/public/defaults.js
@@ -32,7 +32,7 @@ const getUrl = () => `http://localhost:${server.address().port}`;
  * @returns {Promise<Array>} Array of multiple objects, consisting of Page, Browser and Url.
  */
 module.exports.defaultBefore = async (page, browser) => {
-    browser = await puppeteer.launch({ args: ['--no-sandbox'] });
+    browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
     page = await browser.newPage();
     await Promise.all([
         page.coverage.startJSCoverage({ resetOnNavigation: false }),


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for developers:
- Use new headless chrome for pupeteer tests
