### PR TITLE
[O2B-872] Fetch all DPL detectors with at least one executed process

### DIFF
--- a/lib/domain/dtos/DtoFactory.js
+++ b/lib/domain/dtos/DtoFactory.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const Joi = require('joi');
+
+/**
+ * Returns a request DTO which require an empty body & params (in-URL parameters) but with a specific list of query parameters
+ *
+ * @param {object} querySchema the description of query parameters (token is added automatically)
+ * @return {object} the resulting DTO
+ */
+const queryOnlyDtoFactory = (querySchema) => Joi.object({
+    query: {
+        token: Joi.string(),
+        ...querySchema,
+    },
+    body: Joi.object({}),
+    params: Joi.object({}),
+});
+
+exports.DtoFactory = {
+    queryOnly: queryOnlyDtoFactory,
+};

--- a/lib/server/controllers/dplProcess.controller.js
+++ b/lib/server/controllers/dplProcess.controller.js
@@ -19,9 +19,9 @@ const { dplProcessService } = require('../services/dpl/DplProcessService.js');
 
 // eslint-disable-next-line valid-jsdoc
 /**
- * Route to fetch all the detectors that have at least one executed process for a given run
+ * Route to fetch all the dpl detectors that have at least one executed process for a given run
  */
-const getAllDetectorsWithExecutedProcessesByRunHandler = async (request, response) => {
+const getAllDplDetectorsWithExecutedProcessesByRunHandler = async (request, response) => {
     const requestDto = await dtoValidator(
         DtoFactory.queryOnly({ runNumber: Joi.number().required() }),
         request,
@@ -38,5 +38,5 @@ const getAllDetectorsWithExecutedProcessesByRunHandler = async (request, respons
 };
 
 exports.DplProcessController = {
-    getAllDetectorsWithExecutedProcessesByRunHandler,
+    getAllDplDetectorsWithExecutedProcessesByRunHandler,
 };

--- a/lib/server/controllers/dplProcess.controller.js
+++ b/lib/server/controllers/dplProcess.controller.js
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const { dtoValidator } = require('../utilities/index.js');
+const { updateExpressResponseFromNativeError } = require('../express/updateExpressResponseFromNativeError.js');
+const { DtoFactory } = require('../../domain/dtos/DtoFactory.js');
+const Joi = require('joi');
+const { dplProcessService } = require('../services/dpl/DplProcessService.js');
+
+// eslint-disable-next-line valid-jsdoc
+/**
+ * Route to fetch all the detectors that have at least one executed process for a given run
+ */
+const getAllDetectorsWithExecutedProcessesByRunHandler = async (request, response) => {
+    const requestDto = await dtoValidator(
+        DtoFactory.queryOnly({ runNumber: Joi.number().required() }),
+        request,
+        response,
+    );
+    if (requestDto) {
+        try {
+            const data = await dplProcessService.getAllDetectorsWithExecutedProcessesByRun({ runNumber: requestDto.query.runNumber });
+            response.status(200).json({ data });
+        } catch (error) {
+            updateExpressResponseFromNativeError(response, error);
+        }
+    }
+};
+
+exports.DplProcessController = {
+    getAllDetectorsWithExecutedProcessesByRunHandler,
+};

--- a/lib/server/routers/dplProcess.router.js
+++ b/lib/server/routers/dplProcess.router.js
@@ -16,13 +16,12 @@ const { DplProcessController } = require('../controllers/dplProcess.controller.j
 exports.dplProcessRouter = {
     method: 'get',
     path: '/dpl-process',
-    args: { public: true },
+    args: { public: false },
     children: [
         {
             method: 'get',
             path: '/detectors',
-            controller: DplProcessController.getAllDetectorsWithExecutedProcessesByRunHandler,
-            args: { public: true },
+            controller: DplProcessController.getAllDplDetectorsWithExecutedProcessesByRunHandler,
         },
     ],
 };

--- a/lib/server/routers/dplProcess.router.js
+++ b/lib/server/routers/dplProcess.router.js
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const { DplProcessController } = require('../controllers/dplProcess.controller.js');
+
+exports.dplProcessRouter = {
+    method: 'get',
+    path: '/dpl-process',
+    args: { public: true },
+    children: [
+        {
+            method: 'get',
+            path: '/detectors',
+            controller: DplProcessController.getAllDetectorsWithExecutedProcessesByRunHandler,
+            args: { public: true },
+        },
+    ],
+};

--- a/lib/server/routers/index.js
+++ b/lib/server/routers/index.js
@@ -14,6 +14,7 @@ const attachmentRoute = require('./attachments.router');
 const authRoute = require('./auth.router');
 const createpdfRoute = require('./createpdf.router');
 const detectorsRoute = require('./detectors.router');
+const { dplProcessRouter } = require('./dplProcess.router.js');
 const environmentRoute = require('./environments.router');
 const { eosReportRouter } = require('./eosReport.router.js');
 const flpsRoute = require('./flps.router');
@@ -36,6 +37,7 @@ const routes = [
     authRoute,
     createpdfRoute,
     detectorsRoute,
+    dplProcessRouter,
     environmentRoute,
     eosReportRouter,
     flpsRoute,

--- a/lib/server/services/dpl/DplProcessService.js
+++ b/lib/server/services/dpl/DplProcessService.js
@@ -1,0 +1,44 @@
+/**
+ *  @license
+ *  Copyright CERN and copyright holders of ALICE O2. This software is
+ *  distributed under the terms of the GNU General Public License v3 (GPL
+ *  Version 3), copied verbatim in the file "COPYING".
+ *
+ *  See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ *  In applying this license CERN does not waive the privileges and immunities
+ *  granted to it by virtue of its status as an Intergovernmental Organization
+ *  or submit itself to any jurisdiction.
+ */
+
+const { dplDetectorAdapter } = require('../../../database/adapters/index.js');
+const { DplDetectorRepository } = require('../../../database/repositories/index.js');
+const { getRunOrFail } = require('../run/getRunOrFail.js');
+
+/**
+ * DPL service
+ */
+class DplProcessService {
+    /**
+     * Returns all the dpl detectors that have at least one executed process in the given run
+     *
+     * @param {RunIdentifier} runIdentifier the identifier of the run that must have at least one executed process
+     * @return {Promise<DplDetector[]>} the resulting DPL detectors
+     */
+    async getAllDetectorsWithExecutedProcessesByRun(runIdentifier) {
+        const run = await getRunOrFail(runIdentifier);
+
+        return (await DplDetectorRepository.findAll({
+            include: {
+                association: 'processesExecutions',
+                where: {
+                    runNumber: run.runNumber,
+                },
+                required: true,
+                attributes: [],
+            },
+        })).map(dplDetectorAdapter.toEntity);
+    }
+}
+
+exports.dplProcessService = new DplProcessService();

--- a/test/api/dplProcess.test.js
+++ b/test/api/dplProcess.test.js
@@ -1,0 +1,52 @@
+/**
+ *  @license
+ *  Copyright CERN and copyright holders of ALICE O2. This software is
+ *  distributed under the terms of the GNU General Public License v3 (GPL
+ *  Version 3), copied verbatim in the file "COPYING".
+ *
+ *  See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ *  In applying this license CERN does not waive the privileges and immunities
+ *  granted to it by virtue of its status as an Intergovernmental Organization
+ *  or submit itself to any jurisdiction.
+ */
+
+const { resetDatabaseContent } = require('../utilities/resetDatabaseContent.js');
+const request = require('supertest');
+const { server } = require('../../lib/application');
+const { expect } = require('chai');
+const { buildUrl } = require('../../lib/utilities/buildUrl.js');
+
+module.exports = () => {
+    before(resetDatabaseContent);
+
+    describe('GET /api/dpl-process/detectors', async () => {
+        it('Should successfully return the list of detectors that have at least one executed process for the given run', async () => {
+            const response = await request(server).get(buildUrl('/api/dpl-process/detectors', { runNumber: 106 }));
+
+            expect(response.status).to.equal(200);
+            expect(response.body.data).to.be.an('array');
+            expect(response.body.data.map(({ id }) => parseInt(id, 10))).to.eql([1, 2]);
+        });
+
+        it('Should successfully return a 404 when trying to get detectors with a non-existing run number', async () => {
+            const response = await request(server).get(buildUrl('/api/dpl-process/detectors', { runNumber: 999 }));
+
+            expect(response.status).to.equal(404);
+        });
+
+        it('Should successfully return a 400 when trying to get detectors with an invalid run number', async () => {
+            const response = await request(server).get(buildUrl('/api/dpl-process/detectors', { runNumber: 'not-a-number' }));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.runNumber" must be a number');
+        });
+
+        it('Should successfully return a 400 when trying to get detectors without run number', async () => {
+            const response = await request(server).get('/api/dpl-process/detectors');
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.runNumber" is required');
+        });
+    });
+};

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -13,6 +13,7 @@
 
 const AttachmentsSuite = require('./attachments.test.js');
 const DetectorsSuite = require('./detectors.test.js');
+const DPLProcessSuite = require('./dplProcess.test.js');
 const EnvironmentsSuite = require('./environments.test.js');
 const EosReportSuite = require('./eosReport.test.js');
 // TODO [O2B-805] const FlpSuite = require('./flps.test.js');
@@ -28,6 +29,7 @@ const RunTypesSuite = require('./runTypes.test.js');
 module.exports = () => {
     describe('Attachments API', AttachmentsSuite);
     describe('Detectors API', DetectorsSuite);
+    describe('DPL Process API', DPLProcessSuite);
     describe('Environments API', EnvironmentsSuite);
     describe('EOS report API', EosReportSuite);
     // TODO [O2B-805] describe('FLP API', FlpSuite);

--- a/test/lib/server/services/dpl/DplProcessService.test.js
+++ b/test/lib/server/services/dpl/DplProcessService.test.js
@@ -1,0 +1,33 @@
+/**
+ *  @license
+ *  Copyright CERN and copyright holders of ALICE O2. This software is
+ *  distributed under the terms of the GNU General Public License v3 (GPL
+ *  Version 3), copied verbatim in the file "COPYING".
+ *
+ *  See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ *  In applying this license CERN does not waive the privileges and immunities
+ *  granted to it by virtue of its status as an Intergovernmental Organization
+ *  or submit itself to any jurisdiction.
+ */
+
+const { dplProcessService } = require('../../../../../lib/server/services/dpl/DplProcessService.js');
+
+const assert = require('assert');
+const { expect } = require('chai');
+const { NotFoundError } = require('../../../../../lib/server/errors/NotFoundError.js');
+
+module.exports = () => {
+    it('should successfully return the list of detectors that have an executed process for a given run', async () => {
+        const detectors = await dplProcessService.getAllDetectorsWithExecutedProcessesByRun({ runNumber: 106 });
+        expect(detectors.map(({ id }) => id)).to.eql([1, 2]);
+        expect(detectors.every(({ processesExecutions }) => processesExecutions.length === 0)).to.be.true;
+    });
+
+    it('should throw an error if the given run do not exist', async () => {
+        await assert.rejects(
+            () => dplProcessService.getAllDetectorsWithExecutedProcessesByRun({ runNumber: 999 }),
+            new NotFoundError('Run with this run number (999) could not be found'),
+        );
+    });
+};

--- a/test/lib/server/services/dpl/index.js
+++ b/test/lib/server/services/dpl/index.js
@@ -1,0 +1,20 @@
+/**
+ *  @license
+ *  Copyright CERN and copyright holders of ALICE O2. This software is
+ *  distributed under the terms of the GNU General Public License v3 (GPL
+ *  Version 3), copied verbatim in the file "COPYING".
+ *
+ *  See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ *  In applying this license CERN does not waive the privileges and immunities
+ *  granted to it by virtue of its status as an Intergovernmental Organization
+ *  or submit itself to any jurisdiction.
+ */
+
+const { resetDatabaseContent } = require('../../../../utilities/resetDatabaseContent.js');
+const DplProcessServiceTest = require('./DplProcessService.test.js');
+
+module.exports = () => {
+    before(resetDatabaseContent);
+    describe('DplProcessService', DplProcessServiceTest);
+};

--- a/test/lib/server/services/index.js
+++ b/test/lib/server/services/index.js
@@ -12,6 +12,7 @@
  */
 
 const DetectorSuite = require('./detector/index.js');
+const DplSuite = require('./dpl/index.js');
 const Environment = require('./environment/index.js');
 const EnvironmentHistoryItemSuite = require('./environmentHistoryItem/index.js');
 const EosReportSuite = require('./eosReport/index.js');
@@ -23,6 +24,7 @@ const ShiftSuite = require('./shift/index.js');
 
 module.exports = () => {
     describe('Detector', DetectorSuite);
+    describe('DPL', DplSuite);
     describe('Environment', Environment);
     describe('Environment history item', EnvironmentHistoryItemSuite);
     describe('EOS report', EosReportSuite);


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- An endpoint to fetch all DPL detectors that have at least one executed process for a given run has been added
