### PR TITLE
[O2B-867] Fetch all DPL processes executed for a given run and detector

### DIFF
--- a/lib/server/controllers/dplProcess.controller.js
+++ b/lib/server/controllers/dplProcess.controller.js
@@ -41,7 +41,7 @@ const getAllDplDetectorsWithExecutedProcessesByRunHandler = async (request, resp
 /**
  * Route to fetch all the processes that have been executed at least once for a given run and detector
  */
-const getAllExecutedProcessesByRunAndDetectorHandler = async (request, response) => {
+const getAllExecutedProcessesByRunAndDplDetectorHandler = async (request, response) => {
     const requestDto = await dtoValidator(
         DtoFactory.queryOnly({
             runNumber: Joi.number().required(),
@@ -65,5 +65,5 @@ const getAllExecutedProcessesByRunAndDetectorHandler = async (request, response)
 
 exports.DplProcessController = {
     getAllDplDetectorsWithExecutedProcessesByRunHandler,
-    getAllExecutedProcessesByRunAndDetectorHandler,
+    getAllExecutedProcessesByRunAndDplDetectorHandler,
 };

--- a/lib/server/controllers/dplProcess.controller.js
+++ b/lib/server/controllers/dplProcess.controller.js
@@ -37,6 +37,33 @@ const getAllDplDetectorsWithExecutedProcessesByRunHandler = async (request, resp
     }
 };
 
+// eslint-disable-next-line valid-jsdoc
+/**
+ * Route to fetch all the processes that have been executed at least once for a given run and detector
+ */
+const getAllExecutedProcessesByRunAndDetectorHandler = async (request, response) => {
+    const requestDto = await dtoValidator(
+        DtoFactory.queryOnly({
+            runNumber: Joi.number().required(),
+            detectorId: Joi.number().required(),
+        }),
+        request,
+        response,
+    );
+    if (requestDto) {
+        try {
+            const data = await dplProcessService.getAllExecutedProcessesByRunAndDetector(
+                { runNumber: requestDto.query.runNumber },
+                requestDto.query.detectorId,
+            );
+            response.status(200).json({ data });
+        } catch (error) {
+            updateExpressResponseFromNativeError(response, error);
+        }
+    }
+};
+
 exports.DplProcessController = {
     getAllDplDetectorsWithExecutedProcessesByRunHandler,
+    getAllExecutedProcessesByRunAndDetectorHandler,
 };

--- a/lib/server/routers/dplProcess.router.js
+++ b/lib/server/routers/dplProcess.router.js
@@ -27,7 +27,6 @@ exports.dplProcessRouter = {
             method: 'get',
             path: '/processes',
             controller: DplProcessController.getAllExecutedProcessesByRunAndDplDetectorHandler,
-            args: { public: true },
         },
     ],
 };

--- a/lib/server/routers/dplProcess.router.js
+++ b/lib/server/routers/dplProcess.router.js
@@ -26,7 +26,7 @@ exports.dplProcessRouter = {
         {
             method: 'get',
             path: '/processes',
-            controller: DplProcessController.getAllExecutedProcessesByRunAndDetectorHandler,
+            controller: DplProcessController.getAllExecutedProcessesByRunAndDplDetectorHandler,
             args: { public: true },
         },
     ],

--- a/lib/server/routers/dplProcess.router.js
+++ b/lib/server/routers/dplProcess.router.js
@@ -23,5 +23,11 @@ exports.dplProcessRouter = {
             path: '/detectors',
             controller: DplProcessController.getAllDplDetectorsWithExecutedProcessesByRunHandler,
         },
+        {
+            method: 'get',
+            path: '/processes',
+            controller: DplProcessController.getAllExecutedProcessesByRunAndDetectorHandler,
+            args: { public: true },
+        },
     ],
 };

--- a/lib/server/services/dpl/DplProcessService.js
+++ b/lib/server/services/dpl/DplProcessService.js
@@ -11,9 +11,10 @@
  *  or submit itself to any jurisdiction.
  */
 
-const { dplDetectorAdapter } = require('../../../database/adapters/index.js');
-const { DplDetectorRepository } = require('../../../database/repositories/index.js');
+const { dplDetectorAdapter, dplProcessAdapter } = require('../../../database/adapters/index.js');
+const { DplDetectorRepository, DplProcessRepository } = require('../../../database/repositories/index.js');
 const { getRunOrFail } = require('../run/getRunOrFail.js');
+const { getDplDetectorOrFail } = require('./getDplDetectorOrFail.js');
 
 /**
  * DPL service
@@ -38,6 +39,30 @@ class DplProcessService {
                 attributes: [],
             },
         })).map(dplDetectorAdapter.toEntity);
+    }
+
+    /**
+     * Returns the list of all DPL processes that have been executed at least once for the given run and detector
+     *
+     * @param {RunIdentifier} runIdentifier the identifier of the run for which the process must have been executed
+     * @param {number} detectorId the identifier of the detector for which the process must have been executed
+     * @return {Promise<DplProcess[]>} the processes that match the criteria
+     */
+    async getAllExecutedProcessesByRunAndDetector(runIdentifier, detectorId) {
+        const run = await getRunOrFail(runIdentifier);
+        const detector = await getDplDetectorOrFail(detectorId);
+
+        return (await DplProcessRepository.findAll({
+            include: {
+                association: 'processesExecutions',
+                where: {
+                    runNumber: run.runNumber,
+                    detectorId: detector.id,
+                },
+                required: true,
+                attributes: [],
+            },
+        })).map(dplProcessAdapter.toEntity);
     }
 }
 

--- a/lib/server/services/dpl/getDplDetector.js
+++ b/lib/server/services/dpl/getDplDetector.js
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const { utilities: { QueryBuilder } } = require('../../../database');
+const { DplDetectorRepository } = require('../../../database/repositories/index.js');
+
+/**
+ * Find and return a DPL detector model by its id
+ *
+ * @param {number} detectorId the id of the detector to find
+ * @return {Promise<SequelizeDplDetector|null>} the DPL detector found or null
+ */
+exports.getDplDetector = (detectorId) => {
+    const queryBuilder = new QueryBuilder().where('id').is(detectorId);
+    return DplDetectorRepository.findOne(queryBuilder);
+};

--- a/lib/server/services/dpl/getDplDetectorOrFail.js
+++ b/lib/server/services/dpl/getDplDetectorOrFail.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const { NotFoundError } = require('../../errors/NotFoundError.js');
+const { getDplDetector } = require('./getDplDetector.js');
+
+/**
+ * Find a DPL detector model by its id and reject with a NotFoundError if none is found
+ *
+ * @param {number} detectorId the id of the detector to find
+ * @return {Promise<SequelizeDplDetector>} resolve with the DPL detector model found or reject with a NotFoundError
+ */
+exports.getDplDetectorOrFail = async (detectorId) => {
+    const dplDetectorModel = await getDplDetector(detectorId);
+
+    if (dplDetectorModel !== null) {
+        return dplDetectorModel;
+    } else {
+        throw new NotFoundError('DPL detector with this id could not be found');
+    }
+};

--- a/test/api/dplProcess.test.js
+++ b/test/api/dplProcess.test.js
@@ -49,4 +49,101 @@ module.exports = () => {
             expect(response.body.errors[0].detail).to.equal('"query.runNumber" is required');
         });
     });
+
+    describe('GET /api/dpl-process/processes', async () => {
+        it('Should successfully return the list of processes executed at least once for the given run and detector', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/processes',
+                    {
+                        runNumber: 106,
+                        detectorId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(200);
+            expect(response.body.data).to.be.an('array');
+            expect(response.body.data.map(({ id }) => parseInt(id, 10))).to.eql([1, 2, 3]);
+        });
+
+        it('Should successfully return a 404 when trying to get processes with a non-existing run number', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/processes',
+                    {
+                        runNumber: 999,
+                        detectorId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(404);
+        });
+
+        it('Should successfully return a 400 when trying to get processes with an invalid run number', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/processes',
+                    {
+                        runNumber: 'not-a-number',
+                        detectorId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.runNumber" must be a number');
+        });
+
+        it('Should successfully return a 400 when trying to get processes without run number', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/processes',
+                    {
+                        detectorId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.runNumber" is required');
+        });
+
+        it('Should successfully return a 404 when trying to get processes with a non-existing detector id', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/processes',
+                    {
+                        runNumber: 106,
+                        detectorId: 999,
+                    },
+                ));
+
+            expect(response.status).to.equal(404);
+        });
+
+        it('Should successfully return a 400 when trying to get processes with an invalid detector id', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/processes',
+                    {
+                        runNumber: 106,
+                        detectorId: 'not-a-number',
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.detectorId" must be a number');
+        });
+
+        it('Should successfully return a 400 when trying to get processes without detector id', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/processes',
+                    {
+                        runNumber: 106,
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.detectorId" is required');
+        });
+    });
 };

--- a/test/lib/server/services/dpl/DplProcessService.test.js
+++ b/test/lib/server/services/dpl/DplProcessService.test.js
@@ -24,10 +24,30 @@ module.exports = () => {
         expect(detectors.every(({ processesExecutions }) => processesExecutions.length === 0)).to.be.true;
     });
 
-    it('should throw an error if the given run do not exist', async () => {
+    it('should throw an error if trying to fetch detectors for a run that does not exist', async () => {
         await assert.rejects(
             () => dplProcessService.getAllDetectorsWithExecutedProcessesByRun({ runNumber: 999 }),
             new NotFoundError('Run with this run number (999) could not be found'),
+        );
+    });
+
+    it('should successfully return the list of processes that have an executed process for a given run and a given detector', async () => {
+        const processes = await dplProcessService.getAllExecutedProcessesByRunAndDetector({ runNumber: 106 }, 1);
+        expect(processes.map(({ id }) => id)).to.eql([1, 2, 3]);
+        expect(processes.every(({ processesExecutions }) => processesExecutions.length === 0)).to.be.true;
+    });
+
+    it('should throw an error if trying to fetch processes for a run that does not exist', async () => {
+        await assert.rejects(
+            () => dplProcessService.getAllExecutedProcessesByRunAndDetector({ runNumber: 999 }, 1),
+            new NotFoundError('Run with this run number (999) could not be found'),
+        );
+    });
+
+    it('should throw an error if trying to fetch processes for a DPL detector that does not exist', async () => {
+        await assert.rejects(
+            () => dplProcessService.getAllExecutedProcessesByRunAndDetector({ runNumber: 106 }, 999),
+            new NotFoundError('DPL detector with this id could not be found'),
         );
     });
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- An endpoint to fetch all DPL processes that have been executed on a given run and detector has been added
