### PR TITLE
[O2B-871] Fetch all process executions by host & run & detector

### DIFF
--- a/lib/server/controllers/dplProcess.controller.js
+++ b/lib/server/controllers/dplProcess.controller.js
@@ -91,8 +91,39 @@ const getAllHostsWithExecutedProcessByRunAndDplDetectorHandler = async (request,
     }
 };
 
+// eslint-disable-next-line valid-jsdoc
+/**
+ * Route to fetch all executions of a given process on a given host for a given run and detector
+ */
+const getAllProcessExecutionByRunAndDplDetectorAndHostHandler = async (request, response) => {
+    const requestDto = await dtoValidator(
+        DtoFactory.queryOnly({
+            runNumber: Joi.number().required(),
+            detectorId: Joi.number().required(),
+            processId: Joi.number().required(),
+            hostId: Joi.number().required(),
+        }),
+        request,
+        response,
+    );
+    if (requestDto) {
+        try {
+            const data = await dplProcessService.getAllProcessExecutionByRunAndDetectorAndHost(
+                { runNumber: requestDto.query.runNumber },
+                requestDto.query.detectorId,
+                requestDto.query.processId,
+                requestDto.query.hostId,
+            );
+            response.status(200).json({ data });
+        } catch (error) {
+            updateExpressResponseFromNativeError(response, error);
+        }
+    }
+};
+
 exports.DplProcessController = {
     getAllDplDetectorsWithExecutedProcessesByRunHandler,
     getAllExecutedProcessesByRunAndDplDetectorHandler,
     getAllHostsWithExecutedProcessByRunAndDplDetectorHandler,
+    getAllProcessExecutionByRunAndDplDetectorAndHostHandler,
 };

--- a/lib/server/routers/dplProcess.router.js
+++ b/lib/server/routers/dplProcess.router.js
@@ -33,5 +33,10 @@ exports.dplProcessRouter = {
             path: '/hosts',
             controller: DplProcessController.getAllHostsWithExecutedProcessByRunAndDplDetectorHandler,
         },
+        {
+            method: 'get',
+            path: '/executions',
+            controller: DplProcessController.getAllProcessExecutionByRunAndDplDetectorAndHostHandler,
+        },
     ],
 };

--- a/lib/server/services/dpl/DplProcessService.js
+++ b/lib/server/services/dpl/DplProcessService.js
@@ -11,15 +11,22 @@
  *  or submit itself to any jurisdiction.
  */
 
-const { dplDetectorAdapter, dplProcessAdapter, hostAdapter } = require('../../../database/adapters/index.js');
+const {
+    dplDetectorAdapter,
+    dplProcessAdapter,
+    dplProcessExecutionAdapter,
+    hostAdapter,
+} = require('../../../database/adapters/index.js');
 const {
     DplDetectorRepository,
     DplProcessRepository,
     HostRepository,
+    DplProcessExecutionRepository,
 } = require('../../../database/repositories/index.js');
 const { getRunOrFail } = require('../run/getRunOrFail.js');
 const { getDplDetectorOrFail } = require('./getDplDetectorOrFail.js');
 const { getDplProcessOrFail } = require('./getDplProcessOrFail.js');
+const { getHostOrFail } = require('../host/getHostOrFail.js');
 
 /**
  * DPL service
@@ -95,6 +102,33 @@ class DplProcessService {
                 attributes: [],
             },
         })).map(hostAdapter.toEntity);
+    }
+
+    /**
+     * Returns the list of executions of a given process, on a given host, for a given run and detector
+     *
+     * @param {RunIdentifier} runIdentifier the identifier of the run for which the process must have been executed
+     * @param {number} detectorId the identifier of the detector for which the process must have been executed
+     * @param {number} processId the identifier of the process that must have been executed
+     * @param {number} hostId the identifier of the host on which the process must have been executed
+     * @return {Promise<DplProcessExecution[]>} the process executions
+     */
+    async getAllProcessExecutionByRunAndDetectorAndHost(runIdentifier, detectorId, processId, hostId) {
+        const [run, detector, process, host] = await Promise.all([
+            getRunOrFail(runIdentifier),
+            getDplDetectorOrFail(detectorId),
+            getDplProcessOrFail(processId),
+            getHostOrFail(hostId),
+        ]);
+
+        return (await DplProcessExecutionRepository.findAll({
+            where: {
+                runNumber: run.runNumber,
+                detectorId: detector.id,
+                processId: process.id,
+                hostId: host.id,
+            },
+        })).map(dplProcessExecutionAdapter.toEntity);
     }
 }
 

--- a/lib/server/services/host/getHost.js
+++ b/lib/server/services/host/getHost.js
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const { utilities: { QueryBuilder } } = require('../../../database');
+const { HostRepository } = require('../../../database/repositories/index.js');
+
+/**
+ * Find and return a host model by its id
+ *
+ * @param {number} hostId the id of the host to find
+ * @return {Promise<SequelizeHost|null>} the host found or null
+ */
+exports.getHost = (hostId) => {
+    const queryBuilder = new QueryBuilder().where('id').is(hostId);
+    return HostRepository.findOne(queryBuilder);
+};

--- a/lib/server/services/host/getHostOrFail.js
+++ b/lib/server/services/host/getHostOrFail.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+const { NotFoundError } = require('../../errors/NotFoundError.js');
+const { getHost } = require('./getHost.js');
+
+/**
+ * Find a host model by its id and reject with a NotFoundError if none is found
+ *
+ * @param {number} hostId the id of the host to find
+ * @return {Promise<SequelizeHost>} resolve with the host model found or reject with a NotFoundError
+ */
+exports.getHostOrFail = async (hostId) => {
+    const hostModel = await getHost(hostId);
+
+    if (hostModel !== null) {
+        return hostModel;
+    } else {
+        throw new NotFoundError('Host with this id could not be found');
+    }
+};

--- a/test/api/dplProcess.test.js
+++ b/test/api/dplProcess.test.js
@@ -24,6 +24,7 @@ module.exports = () => {
         it('Should successfully return the list of detectors that have at least one executed process for the given run', async () => {
             const response = await request(server).get(buildUrl('/api/dpl-process/detectors', { runNumber: 106 }));
 
+            await new Promise((res) => setTimeout(res, 20));
             expect(response.status).to.equal(200);
             expect(response.body.data).to.be.an('array');
             expect(response.body.data.map(({ id }) => parseInt(id, 10))).to.eql([1, 2]);
@@ -291,6 +292,205 @@ module.exports = () => {
 
             expect(response.status).to.equal(400);
             expect(response.body.errors[0].detail).to.equal('"query.processId" is required');
+        });
+    });
+
+    describe('GET /api/dpl-process/executions', async () => {
+        it('Should successfully return the executions of a given process on a given hosts for a given run and detector', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 106,
+                        detectorId: 1,
+                        processId: 1,
+                        hostId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(200);
+            expect(response.body.data).to.be.an('array');
+            expect(response.body.data.map(({ id }) => parseInt(id, 10))).to.eql([2]);
+        });
+
+        it('Should successfully return a 404 when trying to get process executions for non-existing run', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 999,
+                        detectorId: 1,
+                        processId: 1,
+                        hostId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(404);
+        });
+
+        it('Should successfully return a 400 when trying to get process executions with an invalid run number', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 'not-a-number',
+                        detectorId: 1,
+                        processId: 1,
+                        hostId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.runNumber" must be a number');
+        });
+
+        it('Should successfully return a 400 when trying to get process executions without run number', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        detectorId: 1,
+                        processId: 1,
+                        hostId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.runNumber" is required');
+        });
+
+        it('Should successfully return a 404 when trying to get process executions for non-existing detector', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 106,
+                        detectorId: 999,
+                        processId: 1,
+                        hostId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(404);
+        });
+
+        it('Should successfully return a 400 when trying to get process executions with an invalid detector id', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 106,
+                        detectorId: 'not-a-number',
+                        processId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.detectorId" must be a number');
+        });
+
+        it('Should successfully return a 400 when trying to get process executions without detector id', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 106,
+                        processId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.detectorId" is required');
+        });
+
+        it('Should successfully return a 404 when trying to get process executions for non-existing process', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 106,
+                        detectorId: 1,
+                        processId: 999,
+                        hostId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(404);
+        });
+
+        it('Should successfully return a 400 when trying to get process executions with an invalid process id', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 106,
+                        detectorId: 1,
+                        processId: 'not-a-number',
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.processId" must be a number');
+        });
+
+        it('Should successfully return a 400 when trying to get process executions without process id', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 106,
+                        detectorId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.processId" is required');
+        });
+
+        it('Should successfully return a 404 when trying to get process executions for non-existing host', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 106,
+                        detectorId: 1,
+                        processId: 1,
+                        hostId: 999,
+                    },
+                ));
+
+            expect(response.status).to.equal(404);
+        });
+
+        it('Should successfully return a 400 when trying to get process executions with an invalid host id', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 106,
+                        detectorId: 1,
+                        processId: 1,
+                        hostId: 'not-a-number',
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.hostId" must be a number');
+        });
+
+        it('Should successfully return a 400 when trying to get process executions without host id', async () => {
+            const response = await request(server)
+                .get(buildUrl(
+                    '/api/dpl-process/executions',
+                    {
+                        runNumber: 106,
+                        detectorId: 1,
+                        processId: 1,
+                    },
+                ));
+
+            expect(response.status).to.equal(400);
+            expect(response.body.errors[0].detail).to.equal('"query.hostId" is required');
         });
     });
 };

--- a/test/lib/server/services/dpl/DplProcessService.test.js
+++ b/test/lib/server/services/dpl/DplProcessService.test.js
@@ -77,4 +77,37 @@ module.exports = () => {
             new NotFoundError('DPL process with this id could not be found'),
         );
     });
+
+    it('should successfully return the list of execution of a given process on a given host for a given run and a given detector', async () => {
+        const processesExecutions = await dplProcessService.getAllProcessExecutionByRunAndDetectorAndHost({ runNumber: 106 }, 1, 1, 1);
+        expect(processesExecutions.map(({ id }) => id)).to.eql([2]);
+    });
+
+    it('should throw an error if trying to fetch process executions for a run that does not exist', async () => {
+        await assert.rejects(
+            () => dplProcessService.getAllProcessExecutionByRunAndDetectorAndHost({ runNumber: 999 }, 1, 1, 1),
+            new NotFoundError('Run with this run number (999) could not be found'),
+        );
+    });
+
+    it('should throw an error if trying to fetch process executions for a DPL detector that does not exist', async () => {
+        await assert.rejects(
+            () => dplProcessService.getAllProcessExecutionByRunAndDetectorAndHost({ runNumber: 106 }, 999, 1, 1),
+            new NotFoundError('DPL detector with this id could not be found'),
+        );
+    });
+
+    it('should throw an error if trying to fetch process executions for a DPL process that does not exist', async () => {
+        await assert.rejects(
+            () => dplProcessService.getAllProcessExecutionByRunAndDetectorAndHost({ runNumber: 106 }, 1, 999, 1),
+            new NotFoundError('DPL process with this id could not be found'),
+        );
+    });
+
+    it('should throw an error if trying to fetch process executions for a host that does not exist', async () => {
+        await assert.rejects(
+            () => dplProcessService.getAllProcessExecutionByRunAndDetectorAndHost({ runNumber: 106 }, 1, 1, 999),
+            new NotFoundError('Host with this id could not be found'),
+        );
+    });
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- An API endpoint to fetch all the executions of a given process, on a given host for a given run & detector