### PR TITLE
[release/0.55.2] 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.55.2](https://github.com/AliceO2Group/Bookkeeping/releases/tag/%40aliceo2%2Fbookkeeping%400.55.2)
+* Notable changes for users:
+  *  Runs will be definied as Definition `PHYSICS` only if they include both detectors `FT0` and `ITS`. This change will also apply to previous runs
+
 ## [0.55.1](https://github.com/AliceO2Group/Bookkeeping/releases/tag/%40aliceo2%2Fbookkeeping%400.55.1)
 * Notable changes for users:
   * QC/PDP EoS report now includes the following tags: QC-PDP shifter, QC, PDP, EoS

--- a/lib/public/views/About/Overview/index.js
+++ b/lib/public/views/About/Overview/index.js
@@ -21,7 +21,7 @@ import { table } from '../../../components/common/table/table.js';
  */
 const aboutOverview = () => {
     const data = [
-        { type: 'Bookkeeping', version: '0.55.1', hostname: '-', port: '4000' },
+        { type: 'Bookkeeping', version: '0.55.2', hostname: '-', port: '4000' },
         { type: 'NPM', version: '', hostname: '', port: '' },
     ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/bookkeeping",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/bookkeeping",
-      "version": "0.55.1",
+      "version": "0.55.2",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "cls-hooked",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/bookkeeping",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "author": "ALICEO2",
   "scripts": {
     "coverage": "nyc npm test && npm run coverage:report",


### PR DESCRIPTION
* Notable changes for users:
  *  Runs will be definied as Definition `PHYSICS` only if they include both detectors `FT0` and `ITS`. This change will also apply to previous runs
