### PR TITLE
[O2B-886] Add total TF size alongside the total CTF size on lhc fill display

### DIFF
--- a/lib/public/services/lhcFill/LhcFillStatisticsExtractor.js
+++ b/lib/public/services/lhcFill/LhcFillStatisticsExtractor.js
@@ -58,6 +58,7 @@ export class LhcFillStatisticsExtractor {
         this._rawTimeSegments = [];
 
         this._totalCtfFileSize = 0;
+        this._totalTfFileSize = 0;
 
         for (const run of runs) {
             this.addRun(run);
@@ -76,7 +77,7 @@ export class LhcFillStatisticsExtractor {
      * @return {void}
      */
     addRun(run) {
-        const { runQuality, detectors, startTime, endTime, ctfFileSize } = run;
+        const { runQuality, detectors, startTime, endTime, ctfFileSize, tfFileSize } = run;
 
         // If the run do not overlap with LHC fill at all or is not well-defined, do not consider it
         if (
@@ -112,6 +113,11 @@ export class LhcFillStatisticsExtractor {
         const numericCtfFileSize = parseInt(ctfFileSize, 10);
         if (!isNaN(numericCtfFileSize)) {
             this._totalCtfFileSize += numericCtfFileSize;
+        }
+
+        const numericTfFileSize = parseInt(tfFileSize, 10);
+        if (!isNaN(numericTfFileSize)) {
+            this._totalTfFileSize += numericTfFileSize;
         }
     }
 
@@ -162,6 +168,7 @@ export class LhcFillStatisticsExtractor {
             meanRunDuration: totalRunsDuration / this._rawTimeSegments.length,
             runsCoverage,
             totalCtfFileSize: this._totalCtfFileSize,
+            totalTfFileSize: this._totalTfFileSize,
         };
     }
 }

--- a/lib/public/views/LhcFills/Detail/lhcFillDetailsComponent.js
+++ b/lib/public/views/LhcFills/Detail/lhcFillDetailsComponent.js
@@ -36,7 +36,11 @@ export const stableBeamStatisticsDisplayConfiguration = [
             format: (efficiency) => formatPercentage(efficiency),
         },
         totalCtfFileSize: {
-            name: 'Total CTF ',
+            name: 'Total CTF size',
+            format: formatFileSize,
+        },
+        totalTfFileSize: {
+            name: 'Total TF size',
             format: formatFileSize,
         },
     },

--- a/test/public/lhcFills/detail.test.js
+++ b/test/public/lhcFills/detail.test.js
@@ -62,6 +62,8 @@ module.exports = () => {
         expect(efficiency.endsWith('41.67%')).to.be.true;
         const totalCtf = await page.$eval('#lhc-fill-totalCtfFileSize', (element) => element.innerText);
         expect(totalCtf.endsWith('67.9569 GB')).to.be.true;
+        const totalTf = await page.$eval('#lhc-fill-totalTfFileSize', (element) => element.innerText);
+        expect(totalTf.endsWith('741.801 GB')).to.be.true;
         const durationBeforeFirstRun = await page.$eval('#lhc-fill-durationBeforeFirstRun', (element) => element.innerText);
         expect(durationBeforeFirstRun.endsWith('03:00:00 (25.00%)')).to.be.true;
         const durationAfterLastRun = await page.$eval('#lhc-fill-durationAfterLastRun', (element) => element.innerText);


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- Adds total TF size display to LHC fill details, renamed 'total CTF' to 'total CTF size'