### PR TITLE
[OB2-904] API fetch top level logs

### DIFF
--- a/lib/database/adapters/LogAdapter.js
+++ b/lib/database/adapters/LogAdapter.js
@@ -66,6 +66,7 @@ class LogAdapter {
             rootLogId,
             parentLogId,
             replies,
+            replyLogs,
             tags: sequelizTags,
             runs,
             subsystems: sequelizeSubsytems,
@@ -95,6 +96,10 @@ class LogAdapter {
 
         if (replies) {
             entityObject.replies = replies;
+        }
+
+        if (replyLogs) {
+            entityObject.replyLogs = replyLogs;
         }
 
         return entityObject;

--- a/lib/database/repositories/LogRepository.js
+++ b/lib/database/repositories/LogRepository.js
@@ -20,6 +20,7 @@ const {
     },
 } = require('../');
 const Repository = require('./Repository');
+const { logAdapter } = require('../adapters');
 
 /**
  * Sequelize implementation of the LogRepository.
@@ -54,6 +55,39 @@ class LogRepository extends Repository {
         });
 
         return rows;
+    }
+
+    /**
+     * Adds an array of reply logs onto every applicable log.
+     * @param {Array} rows - The collection of rows already fetched.
+     * @returns {Promise<Array>} - A promise that resolves to an array of log objects with their reply logs.
+     */
+    async addReplyLogsByRootLog(rows) {
+        /**
+         * Filters the rows to get the top-level logs (logs without a parentLogId).
+         * @param {Object} log - The log object.
+         * @returns {boolean} - Returns true if the log is a top-level log.
+         */
+        const filterTopLevelLogs = (log) => !log.parentLogId;
+
+        /**
+         * Retrieves reply logs for a given root log.
+         * @param {Object} log - The root log object.
+         * @returns {Promise<Object>} - A promise that resolves to the log object with its reply logs.
+         */
+        const getReplyLogs = async (log) => {
+            const replyLogs = await this.findAll({ where: { rootLogId: log.id } });
+            const logWithReplyLogs = {
+                ...logAdapter.toEntity(log),
+            };
+
+            logWithReplyLogs.replyLogs = replyLogs.map(logAdapter.toEntity);
+
+            return logWithReplyLogs;
+        };
+
+        const topLevelLogs = rows.filter(filterTopLevelLogs);
+        return Promise.all(topLevelLogs.map(getReplyLogs));
     }
 
     /**

--- a/lib/database/repositories/LogRepository.js
+++ b/lib/database/repositories/LogRepository.js
@@ -76,12 +76,13 @@ class LogRepository extends Repository {
          * @returns {Promise<Object>} - A promise that resolves to the log object with its reply logs.
          */
         const getReplyLogs = async (log) => {
-            const replyLogs = await this.findAll({ where: { rootLogId: log.id } });
+            const replyLogs = await this.findAll({ where: { parentLogId: log.id } });
             const logWithReplyLogs = {
                 ...logAdapter.toEntity(log),
+                replyLogs: [],
             };
 
-            logWithReplyLogs.replyLogs = replyLogs.map(logAdapter.toEntity);
+            logWithReplyLogs.replyLogs = await Promise.all(replyLogs.map(getReplyLogs));
 
             return logWithReplyLogs;
         };

--- a/lib/presentation/log/toTreeView.js
+++ b/lib/presentation/log/toTreeView.js
@@ -19,7 +19,12 @@
  * @returns {Object} The Log tree.
  */
 const toTreeView = (root, children) => {
-    // eslint-disable-next-line require-jsdoc
+    /**
+     * Traverses the tree to find the node with the specified ID.
+     * @param {Object} obj - The current node being traversed.
+     * @param {string} id - The ID of the node to find.
+     * @returns {Object|null} - The node with the specified ID, or null if not found.
+     */
     const traverse = (obj, id) => {
         if (obj.id === id) {
             return obj;
@@ -35,18 +40,23 @@ const toTreeView = (root, children) => {
         return null;
     };
 
+    const visitedLogs = new Set();
+
     for (const child of children) {
         if (!Array.isArray(child.children)) {
             child.children = [];
         }
 
         const parent = traverse(root, child.parentLogId);
-        if (parent) {
+        if (parent && child.id !== parent.id) { // Exclude parent log from being added as a child
             if (!Array.isArray(parent.children)) {
                 parent.children = [];
             }
 
-            parent.children.push(child);
+            if (!visitedLogs.has(child.id)) {
+                parent.children.push(child);
+                visitedLogs.add(child.id);
+            }
         }
     }
 

--- a/lib/public/components/common/table/rows.js
+++ b/lib/public/components/common/table/rows.js
@@ -57,7 +57,7 @@ const cell = (rowId, column, rowData) => {
 /**
  * Renders a list of rows with content
  *
- * @param {Object[]} data the data to display. Each item property must match the key in columns list if the property
+ * @param {Object[]} data the data to display. Each item property must match the key in columns list if the propety
  *     must be displayed as this column's value
  * @param {string} idKey the key of the column from which row identifier must be extracted
  * @param {Column[]} columns the list of columns to display

--- a/lib/usecases/log/GetAllLogsUseCase.js
+++ b/lib/usecases/log/GetAllLogsUseCase.js
@@ -37,9 +37,10 @@ class GetAllLogsUseCase {
      * Executes this use case.
      *
      * @param {Partial<GetAllLogsDto>} dto The GetAllLogs DTO which contains all request data.
+     * @param {Boolean} allLogsNeeded If true, all logs will be returned, otherwise only the top level logs with replies nested inside.
      * @returns {Promise} Promise object represents the result of this use case.
      */
-    async execute(dto = {}) {
+    async execute(dto = {}, allLogsNeeded = false) {
         const queryBuilder = new QueryBuilder();
         const { query = {} } = dto;
         const { filter, sort = { id: 'desc' }, page = {} } = query;
@@ -172,11 +173,14 @@ class GetAllLogsUseCase {
             return LogRepository.findAndCountAll(queryBuilder);
         });
 
+        const logsWithChildren = await LogRepository.addReplyLogsByRootLog(rows);
+        const rowsWithRepliesAndReplyCount = await LogRepository.addChildrenCountByRootLog(logsWithChildren);
+
         const rowsWithReplies = await LogRepository.addChildrenCountByRootLog(rows);
 
         return {
             count,
-            logs: rowsWithReplies.map(logAdapter.toEntity),
+            logs: allLogsNeeded ? rowsWithReplies.map(logAdapter.toEntity) : rowsWithRepliesAndReplyCount.map(logAdapter.toEntity),
         };
     }
 }

--- a/lib/usecases/log/GetLogTreeUseCase.js
+++ b/lib/usecases/log/GetLogTreeUseCase.js
@@ -46,7 +46,7 @@ class GetLogTreeUseCase {
             rootLog = await new GetLogUseCase().execute({ params: { logId: log.rootLogId } });
         }
 
-        const logs = await new GetAllLogsUseCase().execute({ query: { filter: { rootLog: rootLog.id }, sort: { id: 'asc' } } });
+        const logs = await new GetAllLogsUseCase().execute({ query: { filter: { rootLogId: log.rootLogId }, sort: { id: 'asc' } } }, true);
 
         return toTreeView(rootLog, logs.logs);
     }


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- Only the top level logs are shown in the log table, replies are not temporarily only visible when going to the detail page of a top level log.

Notable changes for developers:
- `getAllLogsUseCase.js` modified, the `execute()` method now takes a new parameter called allLogsNeeded. If it's false only the top level logs will be returned with the replies nested inside. toTreeView edited to filter out the root log which would be in the tree twice.
