### PR TITLE
[OGUI-1349] Group DEV dependencies for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,24 @@ updates:
     day: "tuesday"
     time: "07:00"
     timezone: "Europe/Zurich"
+  groups:
+    dev-dependencies:
+      patterns:
+        - "chai"
+        - "eslint"
+        - "js-yaml"
+        - "mocha"
+        - "nodemon"
+        - "nyc"
+        - "puppeteer"
+        - "puppeteer-to-istanbul"
+        - "sequelize-cli"
+        - "sinon"
+        - "supertest"
+    grpc:
+      patterns:
+      - "@grpc/grpc-js"
+      - "@grpc/proto-loader"
   open-pull-requests-limit: 10
   versioning-strategy: increase
   ignore:


### PR DESCRIPTION
#### I have a JIRA ticket
- [ ] branch and/or PR name(s) include(s) JIRA ID
- [ ] issue has "Fix version" assigned
- [ ] issue "Status" is set to "In review"
- [ ] PR labels are selected

Notable changes for users:
-

Notable changes for developers:
- Use grouping functionality from Dependabot to group dev deps into one PR when there is a new version
 
Changes made to the database:
-
