### PR TITLE
'Active filters' no longer covers 'overview' tab

### DIFF
--- a/lib/public/views/Runs/Overview/index.js
+++ b/lib/public/views/Runs/Overview/index.js
@@ -44,7 +44,7 @@ const showRunsTable = (model, runs) => {
         PAGE_USED_HEIGHT,
     ));
 
-    const content = model.runs.getActiveFilters().join(', ')
+    const content = model.runs.getActiveFilters().join(', ');
 
     return [
         h('.flex-row.header-container.pv2', [

--- a/lib/public/views/Runs/Overview/index.js
+++ b/lib/public/views/Runs/Overview/index.js
@@ -19,6 +19,7 @@ import { filtersPanel } from '../../../components/Filters/common/filtersPanel.js
 import { filtersToggleButton } from '../../../components/Filters/common/filtersToggleButton.js';
 import { estimateDisplayableRowsCount } from '../../../utilities/estimateDisplayableRowsCount.js';
 import { paginationComponent } from '../../../components/Pagination/paginationComponent.js';
+import { overflowBalloon } from '../../../components/common/popover/overflowBalloon.js';
 
 const TABLEROW_HEIGHT = 59;
 // Estimate of the navbar and pagination elements height total; Needs to be updated in case of changes;
@@ -43,6 +44,8 @@ const showRunsTable = (model, runs) => {
         PAGE_USED_HEIGHT,
     ));
 
+    const content = model.runs.getActiveFilters().join(', ')
+
     return [
         h('.flex-row.header-container.pv2', [
             filtersToggleButton(model.runs),
@@ -50,7 +53,7 @@ const showRunsTable = (model, runs) => {
             h(
                 `.w-60.mh3${model.runs.isAnyFilterActive() && !model.runs.areFiltersVisible ? '.display-block' : '.display-none'}`,
                 h('.f5'),
-                `Active filters: ${model.runs.getActiveFilters().join(', ')}`,
+                overflowBalloon(`Active filters: ${content}`),
             ),
             exportRunsButton(model),
         ]),

--- a/lib/public/views/Runs/Overview/index.js
+++ b/lib/public/views/Runs/Overview/index.js
@@ -48,7 +48,7 @@ const showRunsTable = (model, runs) => {
             filtersToggleButton(model.runs),
             filtersPanel(model, model.runs, runsActiveColumns),
             h(
-                `.w-60.filters${model.runs.isAnyFilterActive() && !model.runs.areFiltersVisible ? '.display-block' : '.display-none'}`,
+                `.w-60.mh3${model.runs.isAnyFilterActive() && !model.runs.areFiltersVisible ? '.display-block' : '.display-none'}`,
                 h('.f5'),
                 `Active filters: ${model.runs.getActiveFilters().join(', ')}`,
             ),


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [ ] if it is a new feature, explain how you plan to use it
- [ ] tests are added
- [ ] documentation was updated or added

Notable changes for users:
- When the Overview tab is clicked while there are active filters, the 'Active filters' bar no longer covers the overview dropdown
