### PR TITLE
Remove stale/bad link in local copy of HyperMD

### DIFF
--- a/lib/public/assets/SmartEditor/README.MD
+++ b/lib/public/assets/SmartEditor/README.MD
@@ -1,2 +1,4 @@
 # Local HyperMD copy
-Extracted from [laobubu](http://laobubu.net/HyperMD/docs/examples/ai1.html)
+Extracted from [laobubu](https://github.com/laobubu/HyperMD/)
+
+Note: HyperMD and the linked site for documentation appears to be no longer maintained.


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [x] if it is a new feature, explain how you plan to use it
- [x] tests are added
- [x] documentation was updated or added

This PR removes a stale link in the readme for HyperMD. The site appears to have been bought by an advertising company, so visiting it could be a security risk?

Also, HyperMD doesn't appear to be maintained anymore so maybe we should consider using something else?