### PR TITLE
Shows 'Collapse all' button for single logs

### DIFF
--- a/lib/public/views/Logs/Details/LogTreeViewModel.js
+++ b/lib/public/views/Logs/Details/LogTreeViewModel.js
@@ -172,10 +172,10 @@ export class LogTreeViewModel extends Observable {
         } catch (error) {
             this._logTreeLeafs = RemoteData.failure(error);
         }
-
+        const isSingleTree = this._logTreeLeafs.isSuccess() ? this._logTreeLeafs.payload.length === 1 : false;
         // Open the fetched log by default
         this._detailedPostsIds = [selectedLogId];
-        this._showAllPosts = false;
+        this._showAllPosts = isSingleTree;
         this.notify();
     }
 }

--- a/test/public/logs/create.test.js
+++ b/test/public/logs/create.test.js
@@ -225,11 +225,8 @@ module.exports = () => {
         const button = await page.$(`a#btn${buttonId}`);
         await button.evaluate((btn) => btn.click());
         await page.waitForTimeout(1000);
-        // Click on "Show all" button
-        const showAllButton = await page.$('#toggleCollapse');
-        await showAllButton.click();
-        await page.waitForTimeout(500);
-        // Verify that the attachment names match the ones we uploaded
+
+        // We expect the log to contain the attachments
         const parsedFirstRowId = parseInt(firstRowId.slice('row'.length, firstRowId.length), 10);
         const attachmentsField = await page.$(`#log-${parsedFirstRowId}-attachments`);
         const attachmentsText = await page.evaluate((element) => element.innerText, attachmentsField);
@@ -299,12 +296,8 @@ module.exports = () => {
 
         await goToPage(page, 'log-detail', { queryParameters: { id: rowId } });
 
-        // Click on "Show all" button
-        const showAllButton = await page.$('#toggleCollapse');
-        await showAllButton.click();
-        await page.waitForTimeout(20);
+        // We expect the log to contain the run number
         const runsField = await page.$(`#log-${rowId}-runs`);
-
         const runsText = await page.evaluate((element) => element.innerText, runsField);
         expect(runsText).to.equal(`Runs:\n${runNumbersStr}`);
     });
@@ -347,10 +340,7 @@ module.exports = () => {
         const rowId = parseInt(firstRowId.replace(/\D/g, ''), 10);
         await goToPage(page, 'log-detail', { queryParameters: { id: rowId } });
 
-        // Click on "Show all" button
-        const showAllButton = await page.$('#toggleCollapse');
-        await showAllButton.click();
-        await page.waitForTimeout(20);
+        // We expect the log to contain the correct run numbers
         const runsField = await page.$(`#log-${rowId}-runs`);
         const runsText = await page.evaluate((element) => element.innerText, runsField);
         for (const runNumber of runNumbers) {


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [ ] if it is a new feature, explain how you plan to use it
- [ ] tests are added
- [ ] documentation was updated or added

Notable changes for users:
- When the log tree view page is displayed for single logs with no replies, the button now shows 'Collapse all' by default
