### PR TITLE
[O2B-963] Fix fill efficiency tooltip value

### DIFF
--- a/lib/public/views/Statistics/StatisticsPage.js
+++ b/lib/public/views/Statistics/StatisticsPage.js
@@ -43,7 +43,7 @@ export const StatisticsPage = ({ statisticsModel }) => h('.flex-grow.flex-column
                             h('h5', `Fill #${x}`),
                             h('.flex-row.items-center.g2', [
                                 h('.tooltip-bullet', { style: 'background-color: blue' }),
-                                h('', `Efficiency: ${y[0].toFixed(2)}`),
+                                h('', `Efficiency: ${y[1].toFixed(2)}`),
                             ]),
                             h('.flex-row.items-center.g2', [
                                 h('.tooltip-bullet', { style: 'background-color: red' }),


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- Fill efficiency tooltip displays the correct value
