### PR TITLE
[O2B-973] Increase github test pipeline timeout

### DIFF
--- a/.github/workflows/bookkeeping.yml
+++ b/.github/workflows/bookkeeping.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for developers:
- Github test pipeline timeout has been increased to 15 minutes
