### PR TITLE
Update GH action nodejs version

### DIFF
--- a/.github/workflows/bookkeeping.yml
+++ b/.github/workflows/bookkeeping.yml
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
+      - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Installing dependencies
         run: npm ci
       - name: Running linter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: '18.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Check released tag matches ALICE O2 naming pattern
       run: |
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: '18.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Install production dependencies
       run: npm install --only=production

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "docker-run": "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build",
     "docker-test": "docker-compose -p test -f docker-compose.yml -p test -f docker-compose.test.yml up --build --abort-on-container-exit"
   },
+  "engines": {
+    "node": ">= 18.x"
+  },
   "dependencies": {
     "@aliceo2/web-ui": "2.4.0",
     "@grpc/grpc-js": "1.9.0",


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [NA] if it is a new feature, explain how you plan to use it
- [NA] tests are added
- [NA] documentation was updated or added

Notable changes for developers:
* GH actions will now use the NodeJS 18 version as per the production environment
* package.json also specifies minimum engines allowed to use
