### PR TITLE
[O2B-1004] Fix overview runs filtering by tags `or`

### DIFF
--- a/lib/usecases/run/GetAllRunsUseCase.js
+++ b/lib/usecases/run/GetAllRunsUseCase.js
@@ -229,7 +229,7 @@ class GetAllRunsUseCase {
         const { limit = ApiConfig.pagination.limit, offset = 0 } = page;
         filteringQueryBuilder.limit(limit);
         filteringQueryBuilder.offset(offset);
-        filteringQueryBuilder.set('attributes', ['id']);
+        filteringQueryBuilder.set('attributes', ['id', 'runNumber']);
         filteringQueryBuilder.set('raw', true);
         for (const property in sort) {
             filteringQueryBuilder.orderBy(property, sort[property]);

--- a/test/lib/usecases/run/GetAllRunsUseCase.test.js
+++ b/test/lib/usecases/run/GetAllRunsUseCase.test.js
@@ -70,6 +70,34 @@ module.exports = () => {
         expect(detectors).to.equal('ACO,CPV,CTP,EMC,FIT,HMP,ITS,MCH,MFT,MID,PHS,TOF,TPC,TRD,ZDC');
     });
 
+    it('should successfully return an array only containing runs found with tags', async () => {
+        {
+            getAllRunsDto.query = {
+                filter: {
+                    tags: { operation: 'and', values: ['FOOD', 'RUN'] },
+                },
+            };
+            const { runs } = await new GetAllRunsUseCase().execute(getAllRunsDto);
+            expect(runs).to.lengthOf(1);
+            const [run] = runs;
+            const tagTexts = run.tags.map(({ text }) => text);
+            expect(tagTexts.includes('FOOD') && tagTexts.includes('RUN')).to.be.true;
+        }
+        {
+            getAllRunsDto.query = {
+                filter: {
+                    tags: { operation: 'or', values: ['FOOD', 'TEST-TAG-41'] },
+                },
+            };
+            const { runs } = await new GetAllRunsUseCase().execute(getAllRunsDto);
+            expect(runs).to.lengthOf(2);
+            for (const run of runs) {
+                const tagTexts = run.tags.map(({ text }) => text);
+                expect(tagTexts.includes('FOOD') || tagTexts.includes('TEST-TAG-41')).to.be.true;
+            }
+        }
+    });
+
     it('should successfully filter on run definition', async () => {
         const PHYSICS_COUNT = 4;
         const COSMICS_COUNT = 2;


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- Fixed bug for filtering tags using "or"
