### PR TITLE
[O2B-1005] Allow no-justification when run quality goes from none to good or test

### DIFF
--- a/lib/public/views/Runs/Details/RunPatch.js
+++ b/lib/public/views/Runs/Details/RunPatch.js
@@ -1,5 +1,6 @@
 import { Observable } from '/js/src/index.js';
 import { RUN_CALIBRATION_STATUS, RunCalibrationStatus } from '../../../domain/enums/RunCalibrationStatus.js';
+import { RunQualities } from '../../../domain/enums/RunQualities.js';
 
 /**
  * @typedef EorReasonPatch
@@ -36,16 +37,16 @@ export class RunPatch extends Observable {
      */
     isValid() {
         // If we change the run quality, we require a reason
-        const runQualityChangeReasonIsValid = !this.hasRunQualityChange()
-            || Boolean(this._runQualityChangeReason);
+        const runQualityChangeReasonIsValid = !this.requireRunQualityChangeReason()
+            || this._runQualityChangeReason && this._runQualityChangeReason.trim();
 
         // If we change the calibration status, we require a reason
         const calibrationStatusChangeReasonIsValid = !this.requireCalibrationStatusChangeReason
-            || Boolean(this._calibrationStatusChangeReason);
+            || this._calibrationStatusChangeReason && this._calibrationStatusChangeReason.trim();
 
         // If we change the detectors qualities, we require a reason
         const detectorQualityChangeReasonIsValid = !this.hasAnyDetectorsQualityChange()
-            || Boolean(this._detectorsQualitiesChangeReason);
+            || this._detectorsQualitiesChangeReason && this._detectorsQualitiesChangeReason.trim();
 
         return calibrationStatusChangeReasonIsValid && detectorQualityChangeReasonIsValid && runQualityChangeReasonIsValid;
     }
@@ -139,6 +140,16 @@ export class RunPatch extends Observable {
     setRunQuality(runQuality) {
         this._runQuality = runQuality;
         this.notify();
+    }
+
+    /**
+     * States if the current run quality change require justification
+     * @return {boolean} true if the quality change require justification
+     */
+    requireRunQualityChangeReason() {
+        return this.hasRunQualityChange()
+            && !(this._run.runQuality === RunQualities.NONE
+                && (this._runQuality === RunQualities.GOOD || this._runQuality === RunQualities.TEST));
     }
 
     /**

--- a/lib/public/views/Runs/format/formatRunQuality.js
+++ b/lib/public/views/Runs/format/formatRunQuality.js
@@ -41,7 +41,7 @@ export const formatRunQuality = (runDetailsModel, runQuality, run) => {
                 )),
             ),
         ];
-        if (runDetailsModel.runPatch.hasRunQualityChange()) {
+        if (runDetailsModel.runPatch.requireRunQualityChangeReason()) {
             ret.push(h('textarea.form-control.v-resize', {
                 placeholder: 'Reason of the detector(s) quality change',
                 value: runDetailsModel.runPatch.runQualityChangeReason,

--- a/lib/server/services/run/updateRun.js
+++ b/lib/server/services/run/updateRun.js
@@ -21,6 +21,7 @@ const { getRunDefinition, RunDefinition } = require('./getRunDefinition.js');
 const { DEFAULT_RUN_CALIBRATION_STATUS, RunCalibrationStatus } = require('../../../domain/enums/RunCalibrationStatus.js');
 const { logRunQualityChange } = require('./logEntriesCreation/logRunQualityChange.js');
 const { logCalibrationStatusChange } = require('./logEntriesCreation/logCalibrationStatusChange.js');
+const { RunQualities } = require('../../../domain/enums/RunQualities.js');
 
 /**
  * Update the given run
@@ -110,7 +111,10 @@ exports.updateRun = async (identifier, payload, transaction) => {
         // Send notification if run quality has changed
         if (previousRun.runQuality !== runModel.runQuality) {
             const { runQualityChangeReason } = metadata;
-            if (!runQualityChangeReason) {
+            if (!runQualityChangeReason
+                && !(previousRun.runQuality === RunQualities.NONE
+                    && (runModel.runQuality === RunQualities.GOOD || runModel.runQuality === RunQualities.TEST))
+            ) {
                 throw new BadParameterError('Run quality change require a reason');
             }
             await logRunQualityChange(

--- a/test/lib/server/services/run/RunService.test.js
+++ b/test/lib/server/services/run/RunService.test.js
@@ -83,11 +83,38 @@ module.exports = () => {
         expect(run.definition).to.equal(RunDefinition.Physics);
     });
 
-    it('should throw when trying to change run quality without justification', async () => {
+    it('should throw when trying to change run quality without justification except from specific cases', async () => {
+        await assert.rejects(
+            () => runService.update(
+                { runNumber: 1 },
+                { runPatch: { runQuality: RunQualities.TEST } },
+            ),
+            new BadParameterError('Run quality change require a reason'),
+        );
         await assert.rejects(
             () => runService.update(
                 { runNumber: 1 },
                 { runPatch: { runQuality: RunQualities.GOOD } },
+            ),
+            new BadParameterError('Run quality change require a reason'),
+        );
+        await assert.rejects(
+            () => runService.update(
+                { runNumber: 1 },
+                { runPatch: { runQuality: RunQualities.NONE } },
+            ),
+            new BadParameterError('Run quality change require a reason'),
+        );
+        await runService.update(
+            { runNumber: 1 },
+            { runPatch: { runQuality: RunQualities.NONE }, metadata: { runQualityChangeReason: 'Justification' } },
+        );
+        // A log has been created
+        ++lastLogId;
+        await assert.rejects(
+            () => runService.update(
+                { runNumber: 1 },
+                { runPatch: { runQuality: RunQualities.BAD } },
             ),
             new BadParameterError('Run quality change require a reason'),
         );
@@ -262,5 +289,25 @@ module.exports = () => {
         expect(run.calibrationStatus).to.equal(DEFAULT_RUN_CALIBRATION_STATUS);
         // Put back definition to commissioning
         await runService.update({ runNumber }, { runPatch: { definition: RunDefinition.Commissioning } });
+    });
+
+    it('should successfully update run quality without justification in specific use-cases', async () => {
+        const runNumber = 1;
+        await runService.update(
+            { runNumber },
+            { runPatch: { runQuality: RunQualities.NONE }, metadata: { runQualityChangeReason: 'Justification' } },
+        );
+        await runService.update(
+            { runNumber },
+            { runPatch: { runQuality: RunQualities.GOOD } },
+        );
+        await runService.update(
+            { runNumber },
+            { runPatch: { runQuality: RunQualities.NONE }, metadata: { runQualityChangeReason: 'Justification' } },
+        );
+        await runService.update(
+            { runNumber },
+            { runPatch: { runQuality: RunQualities.TEST } },
+        );
     });
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- Allow editing run quality from none to good or test without justification
