### PR TITLE
[O2B-1012] - Filter by run number in overview

### DIFF
--- a/lib/public/components/Filters/RunsFilter/runNumber.js
+++ b/lib/public/components/Filters/RunsFilter/runNumber.js
@@ -18,7 +18,7 @@ import { h } from '/js/src/index.js';
  * @param {RunModel} runModel the run model object
  * @return {vnode} A text box that lets the user look for logs with a specific author
  */
-const runNumberFilter = (runModel) => h('input.w-75.mt1', {
+const runNumberFilter = (runModel) => h('input.w-75', {
     type: 'text',
     id: 'runNumber',
     value: runModel.getRunNumberFilter(),

--- a/lib/public/views/Runs/Overview/index.js
+++ b/lib/public/views/Runs/Overview/index.js
@@ -47,7 +47,7 @@ const showRunsTable = (model, runs) => {
         h('.flex-row.header-container.pv2', [
             filtersToggleButton(model.runs),
             filtersPanel(model, model.runs, runsActiveColumns),
-            !model.runs.areFiltersVisible && h('.pl2.w-20', runNumberFilter(model.runs)),
+            !model.runs.areFiltersVisible && h('.pl2.w-20#runOverviewFilter', runNumberFilter(model.runs)),
             exportRunsButton(model),
         ]),
         h('.flex-column.w-100', [

--- a/lib/public/views/Runs/Overview/index.js
+++ b/lib/public/views/Runs/Overview/index.js
@@ -19,7 +19,7 @@ import { filtersPanel } from '../../../components/Filters/common/filtersPanel.js
 import { filtersToggleButton } from '../../../components/Filters/common/filtersToggleButton.js';
 import { estimateDisplayableRowsCount } from '../../../utilities/estimateDisplayableRowsCount.js';
 import { paginationComponent } from '../../../components/Pagination/paginationComponent.js';
-
+import runNumberFilter from '../../../components/Filters/RunsFilter/runNumber.js';
 const TABLEROW_HEIGHT = 59;
 // Estimate of the navbar and pagination elements height total; Needs to be updated in case of changes;
 const PAGE_USED_HEIGHT = 215;
@@ -47,6 +47,7 @@ const showRunsTable = (model, runs) => {
         h('.flex-row.header-container.pv2', [
             filtersToggleButton(model.runs),
             filtersPanel(model, model.runs, runsActiveColumns),
+            !model.runs.areFiltersVisible && h('.pl2.w-20', runNumberFilter(model.runs)),
             exportRunsButton(model),
         ]),
         h('.flex-column.w-100', [

--- a/test/public/runs/overview.test.js
+++ b/test/public/runs/overview.test.js
@@ -674,12 +674,13 @@ module.exports = () => {
 
         /**
          * This is the sequence to test filtering the runs on run numbers.
-         *
+         * @param {string} selector Specific selector for each case
          * @return {void}
          */
-        const filterOnRun = async () => {
-            expect(await page.$eval(runNumberInputSelector, (input) => input.placeholder)).to.equal('e.g. 534454, 534455...');
-            await page.type(runNumberInputSelector, inputValue, { delay: 200 });
+        const filterOnRun = async (selector) => {
+            expect(await page.$eval(selector, (input) => input.placeholder)).to.equal('e.g. 534454, 534455...');
+            await page.focus(selector);
+            await page.keyboard.type(inputValue);
             await page.waitForTimeout(500);
             // Validate amount in the table
             table = await page.$$('tbody tr');
@@ -688,19 +689,18 @@ module.exports = () => {
         };
 
         // First filter validation on the main page.
-        await filterOnRun();
+        await filterOnRun(`#runOverviewFilter > ${runNumberInputSelector}`);
 
         // Validate if the filter tab value is equal to the main page value.
         await page.$eval('#openFilterToggle', (element) => element.click());
-
-        expect(await page.$eval(runNumberInputSelector).value).to.equal(inputValue);
+        expect(await page.$eval(runNumberInputSelector, (input) => input.value)).to.equal(inputValue);
 
         // Test if it works in the filter tab.
         await reloadPage(page);
         await page.$eval('#openFilterToggle', (element) => element.click());
 
         // Run the same test sequence on the filter tab.
-        await filterOnRun();
+        await filterOnRun(runNumberInputSelector);
     });
 
     it('should successfully filter on a list of fill numbers and inform the user about it', async () => {


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [ ] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- A second input field is visible to filter runs. This input is visible in the main overview screen without opening the filter tab.

Notable changes for developers:
- N/A

Changes made to the database:
- N/A


A new search input for the runs overview is created. It is synced with the search bar in the filter. Furthermore, the filter test is expanded to facilitate both filter methods independently.
