### PR TITLE
[O2B-1037] Pluralize calibration statuses filter

### DIFF
--- a/lib/domain/dtos/filters/RunFilterDto.js
+++ b/lib/domain/dtos/filters/RunFilterDto.js
@@ -32,7 +32,7 @@ const EorReasonFilterDto = Joi.object({
 
 exports.RunFilterDto = Joi.object({
     runNumbers: Joi.string().trim(),
-    calibrationStatus: Joi.array().items(...RUN_CALIBRATION_STATUS),
+    calibrationStatuses: Joi.array().items(...RUN_CALIBRATION_STATUS),
     definitions: CustomJoi.stringArray().items(Joi.string().uppercase().trim().valid(...RUN_DEFINITIONS)),
     eorReason: EorReasonFilterDto,
     tags: TagsFilterDto,

--- a/lib/usecases/run/GetAllRunsUseCase.js
+++ b/lib/usecases/run/GetAllRunsUseCase.js
@@ -38,7 +38,7 @@ class GetAllRunsUseCase {
 
         if (filter) {
             const {
-                calibrationStatus,
+                calibrationStatuses,
                 dcs,
                 ddflp,
                 definitions,
@@ -69,8 +69,8 @@ class GetAllRunsUseCase {
                 filteringQueryBuilder.where('runNumber').oneOf(...runNumberList);
             }
 
-            if (calibrationStatus) {
-                filteringQueryBuilder.where('calibrationStatus').oneOf(...calibrationStatus);
+            if (calibrationStatuses) {
+                filteringQueryBuilder.where('calibrationStatus').oneOf(...calibrationStatuses);
             }
 
             if (runTypes) {

--- a/test/api/runs.test.js
+++ b/test/api/runs.test.js
@@ -131,7 +131,7 @@ module.exports = () => {
         });
 
         it('should successfully filter on calibration', async () => {
-            const response = await request(server).get(`/api/runs?filter[calibrationStatus][]=${RunCalibrationStatus.NO_STATUS}`);
+            const response = await request(server).get(`/api/runs?filter[calibrationStatuses][]=${RunCalibrationStatus.NO_STATUS}`);
 
             expect(response.status).to.equal(200);
             const { data: runs } = response.body;
@@ -142,22 +142,22 @@ module.exports = () => {
 
         it('should return 400 if the calibration status filter is invalid', async () => {
             {
-                const response = await request(server).get('/api/runs?filter[calibrationStatus]=invalid');
+                const response = await request(server).get('/api/runs?filter[calibrationStatuses]=invalid');
 
                 expect(response.status).to.equal(400);
 
                 const { errors: [error] } = response.body;
                 expect(error.title).to.equal('Invalid Attribute');
-                expect(error.detail).to.equal('"query.filter.calibrationStatus" must be an array');
+                expect(error.detail).to.equal('"query.filter.calibrationStatuses" must be an array');
             }
             {
-                const response = await request(server).get('/api/runs?filter[calibrationStatus][]=DO-NOT-EXIST');
+                const response = await request(server).get('/api/runs?filter[calibrationStatuses][]=DO-NOT-EXIST');
 
                 expect(response.status).to.equal(400);
 
                 const { errors: [error] } = response.body;
                 expect(error.title).to.equal('Invalid Attribute');
-                expect(error.detail).to.equal('"query.filter.calibrationStatus[0]" does not match any of the allowed types');
+                expect(error.detail).to.equal('"query.filter.calibrationStatuses[0]" does not match any of the allowed types');
             }
         });
 

--- a/test/lib/usecases/run/GetAllRunsUseCase.test.js
+++ b/test/lib/usecases/run/GetAllRunsUseCase.test.js
@@ -73,7 +73,7 @@ module.exports = () => {
 
     it('should successfully return a list of runs with the specified calibration status', async () => {
         {
-            getAllRunsDto.query = { filter: { calibrationStatus: [RunCalibrationStatus.NO_STATUS] } };
+            getAllRunsDto.query = { filter: { calibrationStatuses: [RunCalibrationStatus.NO_STATUS] } };
             const { runs } = await new GetAllRunsUseCase().execute(getAllRunsDto);
             expect(runs).to.lengthOf(1);
             const [{ calibrationStatus }] = runs;
@@ -81,7 +81,7 @@ module.exports = () => {
         }
 
         {
-            getAllRunsDto.query = { filter: { calibrationStatus: [RunCalibrationStatus.NO_STATUS, RunCalibrationStatus.FAILED] } };
+            getAllRunsDto.query = { filter: { calibrationStatuses: [RunCalibrationStatus.NO_STATUS, RunCalibrationStatus.FAILED] } };
             const { runs } = await new GetAllRunsUseCase().execute(getAllRunsDto);
             expect(runs).to.lengthOf(1);
             const [{ calibrationStatus }] = runs;
@@ -89,13 +89,13 @@ module.exports = () => {
         }
 
         {
-            getAllRunsDto.query = { filter: { calibrationStatus: [RunCalibrationStatus.FAILED] } };
+            getAllRunsDto.query = { filter: { calibrationStatuses: [RunCalibrationStatus.FAILED] } };
             const { runs } = await new GetAllRunsUseCase().execute(getAllRunsDto);
             expect(runs).to.lengthOf(0);
         }
 
         {
-            getAllRunsDto.query = { filter: { calibrationStatus: [] } };
+            getAllRunsDto.query = { filter: { calibrationStatuses: [] } };
             const { runs } = await new GetAllRunsUseCase().execute(getAllRunsDto);
             expect(runs).to.lengthOf(0);
         }


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- Runs API `calibrationStatus` filter is now `calibrationStatuses` (plural)