### PR TITLE
Handle 0 in formatTimestamp function

### DIFF
--- a/lib/public/utilities/formatting/formatTimestamp.js
+++ b/lib/public/utilities/formatting/formatTimestamp.js
@@ -25,7 +25,7 @@ import { getLocaleDateAndTime } from '../dateUtils.js';
  * @return {vnode|string} the formatted timestamp
  */
 export const formatTimestamp = (timestamp, inline = true) => {
-    if (!timestamp) {
+    if (timestamp === null || timestamp === undefined) {
         return '-';
     }
 


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [X] explain what this PR does

Notable changes for developers:
- formatTimestamp function now properly display `0` timestamp value
