### PR TITLE
[O2B-1050] Fix ordering of LHC fill's related runs (sort them by runNumber)

### DIFF
--- a/lib/database/seeders/20220513153907-eor-reason.js
+++ b/lib/database/seeders/20220513153907-eor-reason.js
@@ -37,20 +37,20 @@ module.exports = {
                     {
                         last_edited_name: 'Anonymous',
                         reason_type_id: 3,
-                        run_id: 2,
+                        run_id: 56,
                         created_at: new Date('2021-08-09'),
                         updated_at: new Date('2021-08-10 15:00:00'),
                     },
                     {
                         last_edited_name: 'Anonymous',
                         reason_type_id: 1,
-                        run_id: 2,
+                        run_id: 54,
                         created_at: new Date('2021-07-09'),
                         updated_at: new Date('2021-07-10 15:00:00'),
                     },
                     {
                         reason_type_id: 2,
-                        run_id: 3,
+                        run_id: 54,
                         created_at: new Date('2020-08-09'),
                         updated_at: new Date('2020-08-10 15:00:00'),
                     },

--- a/lib/database/seeders/20220513153907-eor-reason.js
+++ b/lib/database/seeders/20220513153907-eor-reason.js
@@ -44,7 +44,7 @@ module.exports = {
                     {
                         last_edited_name: 'Anonymous',
                         reason_type_id: 1,
-                        run_id: 54,
+                        run_id: 56,
                         created_at: new Date('2021-07-09'),
                         updated_at: new Date('2021-07-10 15:00:00'),
                     },

--- a/lib/server/services/lhcFill/LhcFillService.js
+++ b/lib/server/services/lhcFill/LhcFillService.js
@@ -72,7 +72,7 @@ class LhcFillService {
                     },
                 ],
             });
-            queryBuilder.orderBy('time_start', 'ASC', 'runs');
+            queryBuilder.orderBy('runNumber', 'ASC', 'runs');
         }
     }
 }

--- a/lib/server/services/lhcFill/LhcFillService.js
+++ b/lib/server/services/lhcFill/LhcFillService.js
@@ -72,6 +72,7 @@ class LhcFillService {
                     },
                 ],
             });
+            queryBuilder.orderBy('time_start', 'ASC', 'runs');
         }
     }
 }


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [ ] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- Fixed the run order in LHC fill API when some of the runs have EoR reason
