### PR TITLE
[O2B-1083] Fix a bug in LHC overview pages, now displaying missing dates as '-' instead of the default epoch time

### DIFF
--- a/lib/database/adapters/LhcFillAdapter.js
+++ b/lib/database/adapters/LhcFillAdapter.js
@@ -49,9 +49,9 @@ class LhcFillAdapter {
 
         return {
             fillNumber,
-            stableBeamsStart: new Date(stableBeamsStart).getTime(),
-            stableBeamsEnd: new Date(stableBeamsEnd).getTime(),
-            stableBeamsDuration,
+            stableBeamsStart: stableBeamsStart ? new Date(stableBeamsStart).getTime() : stableBeamsStart,
+            stableBeamsEnd: stableBeamsEnd ? new Date(stableBeamsEnd).getTime() : stableBeamsEnd,
+            stableBeamsDuration: stableBeamsDuration ? new Date(stableBeamsDuration).getTime() : stableBeamsDuration,
             beamType,
             fillingSchemeName,
             runs,


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please fill up one of the checklist below by changing [ ] to [x].
Remove checklist and/or items that do not apply.
-->

#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [ ] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- Missing dates on the LHC overview pages are now shown to the user as '-' instead of 01/01/1970 01:00:00

Notable changes for developers:
- The LHCFillAdapter now verifies whether a date is null/undefined and refrains from using new Date() when encountering missing values

Changes made to the database:
- None
