### PR TITLE
[O2B-1097] Write environments ids in white in overview page

### DIFF
--- a/lib/public/components/common/selection/infoLoggerButtonGroup/identifierColumnAndActionsDropdown.js
+++ b/lib/public/components/common/selection/infoLoggerButtonGroup/identifierColumnAndActionsDropdown.js
@@ -29,7 +29,7 @@ export const identifierColumnAndActionsDropdown = (page, linkContent, parameters
     h(
         '.flex-row.items-center.btn-group',
         [
-            frontLink(linkContent, page, parameters, { class: 'btn btn-primary' }),
+            frontLink(linkContent, page, parameters, { class: 'btn btn-primary white' }),
             dropdown(
                 h('.btn.btn-group-item.last-item', iconCaretBottom()),
                 h(


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- Environment id is now written in white in the environment overview
