### PR TITLE
[O2B-1104] environment status history API bugfix

### DIFF
--- a/lib/database/repositories/EnvironmentHistoryItemRepository.js
+++ b/lib/database/repositories/EnvironmentHistoryItemRepository.js
@@ -25,7 +25,7 @@ const { timestampToMysql } = require('../../server/utilities/timestampToMysql.js
 const getHistoryDistributionQuery = ({ from, to }) => `
     SELECT statusHistory, COUNT(*) AS count
     FROM (
-        SELECT e.id, GROUP_CONCAT(ehi.status) AS statusHistory
+        SELECT e.id, GROUP_CONCAT(ehi.status ORDER BY ehi.created_at ASC) AS statusHistory
         FROM environments e
         INNER JOIN environments_history_items AS ehi 
         ON e.id = ehi.environment_id


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [ ] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- None

Notable changes for developers:
- Explicitly added an order by created_at date in the environment history query to solve a bug where the tests would sometimes fail due to being in a different order than expected.

Changes made to the database:
- None
