### PR TITLE
[O2B-1087] Rollback usage of RemoteData.map not already available

### DIFF
--- a/lib/public/views/Statistics/StatisticsPageModel.js
+++ b/lib/public/views/Statistics/StatisticsPageModel.js
@@ -101,7 +101,13 @@ class StatisticsTabbedPanelModel extends TabbedPanelModel {
         super(Object.values(STATISTICS_PANELS_KEYS));
         this._observableData = ObservableData.builder()
             .initialValue(RemoteData.notAsked())
-            .apply((remoteData) => remoteData.map({ Success: ({ data }) => data }))
+            // TODO use RemoteData.map when ready
+            .apply((remoteData) => remoteData.match({
+                NotAsked: () => RemoteData.notAsked(),
+                Loading: () => RemoteData.loading(),
+                Success: ({ data }) => RemoteData.success(data),
+                Failure: (error) => RemoteData.failure(error),
+            }))
             .build();
         this._observableData.bubbleTo(this);
 


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for developers:
- Rollback usage of RemoteData.map not already available
