### PR TITLE
Remove chai major update because it uses ES6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,5 +34,7 @@ updates:
   ignore:
     - dependency-name: "*"
       update-types: ["version-update:semver-patch"]
+    - dependency-name: "chai"
+      update-types: ["version-update:semver-major"]
   reviewers:
       - "graduta"


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [X] explain what this PR does

Notable changes for developers:
- Excluded chai major release from dependabot updates because it relies on ES6 and project is not there yet
