### PR TITLE
Fix usage of lastRunNumber during Data Passes synchronization

### DIFF
--- a/lib/server/monalisa-synchronization/MonAlisaSynchronizer.js
+++ b/lib/server/monalisa-synchronization/MonAlisaSynchronizer.js
@@ -82,7 +82,7 @@ class MonAlisaSynchronizer {
      * @private
      */
     _doesDataPassNeedUpdate(dataPass, dataPassesLastRunNumber) {
-        const isLastRunNumberSame = dataPass.lastRun && dataPass.lastRun === dataPassesLastRunNumber[dataPass.name];
+        const isLastRunNumberSame = dataPass.lastRunNumber && dataPass.lastRunNumber === dataPassesLastRunNumber[dataPass.name];
         return !isLastRunNumberSame;
     }
 
@@ -98,7 +98,7 @@ class MonAlisaSynchronizer {
             .set('attributes', ['name'])
             .include((sequelize) => ({
                 association: 'runs',
-                attributes: [[sequelize.fn('max', sequelize.col('runs.run_number')), 'lastRun']],
+                attributes: [[sequelize.fn('max', sequelize.col('runs.run_number')), 'lastRunNumber']],
                 through: { attributes: [] },
             }))
             .groupBy('name');
@@ -106,8 +106,8 @@ class MonAlisaSynchronizer {
         const dataPassesWithLastStoredRunNumber = await DataPassRepository.findAll(queryBuilder);
 
         const lastRunNumbersEntries = dataPassesWithLastStoredRunNumber.map((lastRunData) => {
-            const { name, lastRun } = lastRunData;
-            return [name, lastRun];
+            const { name, 'runs.lastRunNumber': lastRunNumber } = lastRunData;
+            return [name, lastRunNumber];
         });
 
         return Object.fromEntries(lastRunNumbersEntries);

--- a/test/lib/server/monalisa-synchronization/MonAlisaSynchronizer.test.js
+++ b/test/lib/server/monalisa-synchronization/MonAlisaSynchronizer.test.js
@@ -30,6 +30,10 @@ module.exports = () => {
         const monAlisaSynchronizer = new MonAlisaSynchronizer(monAlisaClient);
         const expectedDataPasses = mockDataPasses.filter(({ name }) => extractLhcPeriod(name).year >= YEAR_LOWER_LIMIT);
 
+        // Check whether examining data passes with last runs works correctly;
+        let lastRunNumbers = await monAlisaSynchronizer._getAllDataPassesLastRunNumber();
+        expect(mockDataPasses.every((dataPass) => monAlisaSynchronizer._doesDataPassNeedUpdate(dataPass, lastRunNumbers))).to.be.true;
+
         // Run Synchronization
         await monAlisaSynchronizer._synchronizeDataPassesFromMonAlisa();
 
@@ -66,6 +70,10 @@ module.exports = () => {
                 expect(runs.map(({ runNumber }) => runNumber)).to.have.all.members(expectedRunNumbers);
             }
         }
+
+        // Check whether examining data passes with last runs works correctly;
+        lastRunNumbers = await monAlisaSynchronizer._getAllDataPassesLastRunNumber();
+        expect(mockDataPasses.some((dataPass) => monAlisaSynchronizer._doesDataPassNeedUpdate(dataPass, lastRunNumbers))).to.be.false;
     });
 
     it('Should synchronize Simulation Passes with respect to given year limit and in correct format', async () => {


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [ ] if it is a new feature, explain how you plan to use it
- [x] tests are added
- [ ] documentation was updated or added

Notable changes for users:
- NA

Notable changes for developers:
- Fix usage of lastRunNumber during Data Passes synchronization
- Add test

Changes made to the database:
- NA
