### PR TITLE
Add token to codecov actions

### DIFF
--- a/.github/workflows/bookkeeping.yml
+++ b/.github/workflows/bookkeeping.yml
@@ -41,6 +41,8 @@ jobs:
         run: docker cp $(docker ps -aqlf "name=bookkeeping_application"):/usr/src/app/coverage/coverage-final.json .
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        env:
+            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   linter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [X] explain what this PR does

Notable changes for developers:
- Codecov actions uses a token to work withv4