### PR TITLE
[O2B-1176] Add LHC fills statistics back to LHC fills overview

### DIFF
--- a/lib/public/views/LhcFills/Overview/LhcFillsOverviewModel.js
+++ b/lib/public/views/LhcFills/Overview/LhcFillsOverviewModel.js
@@ -12,6 +12,7 @@
  */
 
 import { OverviewPageModel } from '../../../models/OverviewModel.js';
+import { addStatisticsToLhcFill } from '../../../services/lhcFill/addStatisticsToLhcFill.js';
 
 /**
  * Model for the LHC fills overview page
@@ -35,7 +36,10 @@ export class LhcFillsOverviewModel extends OverviewPageModel {
      * @inheritDoc
      */
     processItems(items) {
-        return super.processItems(items);
+        for (const item of items) {
+            addStatisticsToLhcFill(item);
+        }
+        return items;
     }
 
     // eslint-disable-next-line valid-jsdoc

--- a/test/public/lhcFills/overview.test.js
+++ b/test/public/lhcFills/overview.test.js
@@ -212,6 +212,7 @@ module.exports = () => {
     });
 
     it ('should successfully display some statistics', async () => {
+        await goToPage(page, 'lhc-fill-overview');
         await expectInnerText(page, 'tbody tr td:nth-child(6)', '41.67%');
         await expectInnerText(page, 'tbody tr td:nth-child(7)', '03:00:00\n(25.00%)');
         await expectInnerText(page, 'tbody tr td:nth-child(8)', '02:00:00\n(16.67%)');

--- a/test/public/lhcFills/overview.test.js
+++ b/test/public/lhcFills/overview.test.js
@@ -19,7 +19,7 @@ const {
     goToPage,
     checkColumnBalloon,
 } = require('../defaults');
-const { waitForNetworkIdleAndRedraw, waitForTimeout } = require('../defaults.js');
+const { waitForNetworkIdleAndRedraw, waitForTimeout, expectInnerText } = require('../defaults.js');
 
 const { expect } = chai;
 
@@ -209,5 +209,13 @@ module.exports = () => {
         const [, parametersExpr] = await page.url().split('?');
         const urlParameters = parametersExpr.split('&');
         expect(urlParameters).to.contain('page=run-detail');
+    });
+
+    it ('should successfully display some statistics', async () => {
+        await expectInnerText(page, 'tbody tr td:nth-child(6)', '41.67%');
+        await expectInnerText(page, 'tbody tr td:nth-child(7)', '03:00:00\n(25.00%)');
+        await expectInnerText(page, 'tbody tr td:nth-child(8)', '02:00:00\n(16.67%)');
+        await expectInnerText(page, 'tbody tr td:nth-child(9)', '01:40:00');
+        await expectInnerText(page, 'tbody tr td:nth-child(10)', '05:00:00');
     });
 };

--- a/test/public/lhcFills/overview.test.js
+++ b/test/public/lhcFills/overview.test.js
@@ -213,10 +213,10 @@ module.exports = () => {
 
     it ('should successfully display some statistics', async () => {
         await goToPage(page, 'lhc-fill-overview');
-        await expectInnerText(page, 'tbody tr td:nth-child(6)', '41.67%');
-        await expectInnerText(page, 'tbody tr td:nth-child(7)', '03:00:00\n(25.00%)');
-        await expectInnerText(page, 'tbody tr td:nth-child(8)', '02:00:00\n(16.67%)');
-        await expectInnerText(page, 'tbody tr td:nth-child(9)', '01:40:00');
-        await expectInnerText(page, 'tbody tr td:nth-child(10)', '05:00:00');
+        await expectInnerText(page, 'tbody tr:nth-child(3) td:nth-child(6)', '41.67%');
+        await expectInnerText(page, 'tbody tr:nth-child(3) td:nth-child(7)', '03:00:00\n(25.00%)');
+        await expectInnerText(page, 'tbody tr:nth-child(3) td:nth-child(8)', '02:00:00\n(16.67%)');
+        await expectInnerText(page, 'tbody tr:nth-child(3) td:nth-child(9)', '01:40:00');
+        await expectInnerText(page, 'tbody tr:nth-child(3) td:nth-child(10)', '05:00:00');
     });
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- Fixed fill statistics not being displayed in fill overview
