### PR TITLE
[0B-1152] auto fill environments and lhcFills in log reply

### DIFF
--- a/lib/public/views/Logs/Create/LogReplyModel.js
+++ b/lib/public/views/Logs/Create/LogReplyModel.js
@@ -45,7 +45,7 @@ export class LogReplyModel extends LogCreationModel {
     }
 
     /**
-     * Inherit the title, tags and runs from the parent log
+     * Inherit the title, tags, runs, environments and lhcFills from the parent log
      *
      * @param {Log} parentLog the parent log
      * @return {void}

--- a/lib/public/views/Logs/Create/LogReplyModel.js
+++ b/lib/public/views/Logs/Create/LogReplyModel.js
@@ -51,7 +51,7 @@ export class LogReplyModel extends LogCreationModel {
      * @return {void}
      */
     inheritFromParentLog(parentLog) {
-        const { title, tags, runs } = parentLog;
+        const { title, tags, runs, environments, lhcFills } = parentLog;
 
         this.title = `${title}`;
 
@@ -61,6 +61,14 @@ export class LogReplyModel extends LogCreationModel {
 
         if (!this.runNumbers) {
             this.runNumbers = runs.map(({ runNumber }) => runNumber).join(', ');
+        }
+
+        if (!this.environments) {
+            this.environments = environments.map(({ id }) => id).join(', ');
+        }
+
+        if (!this.lhcFills) {
+            this.lhcFills = lhcFills.map(({ fillNumber }) => fillNumber).join(', ');
         }
     }
 

--- a/test/public/defaults.js
+++ b/test/public/defaults.js
@@ -415,6 +415,28 @@ module.exports.fillInput = async (page, inputSelector, value, events = ['input']
 };
 
 /**
+ * Evaluate and return the value content of a given element handler
+ * @param {{evaluate}} elementHandler the puppeteer handler of the element to inspect
+ * @returns {Promise<XPathResult>} the html content
+ */
+const getInnerValue = async (elementHandler) => await elementHandler.evaluate((element) => element.value);
+
+module.exports.getInnerValue = getInnerValue;
+
+/**
+ * Expect an element to have a given value
+ *
+ * @param {Object} page Puppeteer page object.
+ * @param {string} selector Css selector.
+ * @param {string} value value to search for.
+ * @return {Promise<void>} resolves once the value has been checked
+ */
+module.exports.expectInputValue = async (page, selector, value) => {
+    await page.waitForSelector(selector, { timeout: 200 });
+    expect(await getInnerValue(await page.$(selector))).to.equal(value);
+};
+
+/**
  * Check the differences between the provided expected parameters and the parameters actually received
  *
  * @TODO convert this to not-async

--- a/test/public/logs/create.test.js
+++ b/test/public/logs/create.test.js
@@ -12,7 +12,7 @@
  */
 
 const chai = require('chai');
-const { defaultBefore, defaultAfter, goToPage } = require('../defaults');
+const { defaultBefore, defaultAfter, goToPage, expectInputValue } = require('../defaults');
 const path = require('path');
 const { GetAllLogsUseCase } = require('../../../lib/usecases/log/index.js');
 const { pressElement, expectInnerText, fillInput, checkMismatchingUrlParam, waitForTimeout, waitForNavigation } = require('../defaults.js');
@@ -86,6 +86,14 @@ module.exports = () => {
         await waitForNavigation(page, () => pressElement(page, '#parent-log-details'));
 
         expect(await checkMismatchingUrlParam(page, { ['log-details']: '1' }));
+    });
+
+    it('Should successfully display the autofilled runs, environments and lhcFills when replying', async () => {
+        await goToPage(page, 'log-reply&parentLogId=119');
+
+        await expectInputValue(page, 'input#run-numbers', '2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22');
+        await expectInputValue(page, 'input#environments', 'Dxi029djX, eZF99lH6');
+        await expectInputValue(page, 'input#lhc-fills', '1, 4, 6');
     });
 
     it('can disable submit with invalid data', async () => {


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- When replying to a log, the environment and lhcFill id's are auto filled from their parent

Notable changes for developers:
- New default method expectInputValue, does the same as expectInnerText but then for values instead of innerHTML
