### PR TITLE
[O2B-1188] Remove `info` level form infologger links

### DIFF
--- a/lib/public/services/externalRouting/getInfologgerLinksUrls.js
+++ b/lib/public/services/externalRouting/getInfologgerLinksUrls.js
@@ -37,7 +37,7 @@ export const getInfologgerLinksUrls = ({ environmentId, runNumbers }) => {
         queryObject.run = { match: `${runNumbers.join(',')}` };
     }
 
-    queryObject.severity = { in: ['W', 'E', 'F'] };
+    queryObject.severity = { in: 'W E F' };
 
     /**
      * Formats the URL with the given infologger and query object.

--- a/lib/public/services/externalRouting/getInfologgerLinksUrls.js
+++ b/lib/public/services/externalRouting/getInfologgerLinksUrls.js
@@ -37,6 +37,8 @@ export const getInfologgerLinksUrls = ({ environmentId, runNumbers }) => {
         queryObject.run = { match: `${runNumbers.join(',')}` };
     }
 
+    queryObject.severity = { in: ['W', 'E', 'F'] };
+
     /**
      * Formats the URL with the given infologger and query object.
      * @param {string} origin - The baseURL of the infologger.


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- When clicking any infologger link, only severity warn, error and fatal are displayed