### PR TITLE
[O2B-1201] Extract lhcPeriod from patch and not relations

### DIFF
--- a/lib/server/controllers/gRPC/GRPCRunController.js
+++ b/lib/server/controllers/gRPC/GRPCRunController.js
@@ -61,6 +61,7 @@ class GRPCRunController {
                     eorReasons: relations.eorReasons,
                     userO2Start: relations.userO2Start,
                     userO2Stop: relations.userO2Stop,
+                    lhcPeriodName: relations.lhcPeriod?.name,
                 },
             },
         ));
@@ -118,8 +119,10 @@ class GRPCRunController {
             delete gRPCRunRequest.userO2Stop;
         }
 
-        const { lhcPeriod } = gRPCRunRequest;
-        gRPCRunRequest.lhcPeriod = lhcPeriod ? { name: lhcPeriod } : lhcPeriod;
+        if (gRPCRunRequest.lhcPeriod) {
+            relations.lhcPeriod = { name: gRPCRunRequest.lhcPeriod };
+            delete gRPCRunRequest.lhcPeriod;
+        }
 
         return { run: gRPCRunRequest, relations };
     }

--- a/lib/server/services/run/RunService.js
+++ b/lib/server/services/run/RunService.js
@@ -180,10 +180,9 @@ class RunService {
     async update(identifier, payload) {
         const { runPatch = {}, relations = {}, metadata = {} } = payload;
         const { tagsTexts = null, eorReasons = null, runTypeName = null,
-            userIdentifier = {}, detectorsQualities = [],
+            userIdentifier = {}, detectorsQualities = [], lhcPeriodName = null,
             userO2Start = null, userO2Stop = null } = relations;
 
-        const { lhcPeriod } = runPatch;
         const tags = tagsTexts ? await getAllTagsByTextOrFail(tagsTexts, true) : null;
 
         if (runTypeName) {
@@ -191,9 +190,9 @@ class RunService {
             runPatch.runTypeId = runType.id;
         }
 
-        if (lhcPeriod?.name) {
-            const lhcPeriodEntity = await getOrCreateLhcPeriod({ name: lhcPeriod.name });
-            runPatch.lhcPeriodId = lhcPeriodEntity.id;
+        if (lhcPeriodName) {
+            const lhcPeriod = await getOrCreateLhcPeriod({ name: lhcPeriodName });
+            runPatch.lhcPeriodId = lhcPeriod.id;
         }
 
         let user = null;

--- a/lib/server/services/run/RunService.js
+++ b/lib/server/services/run/RunService.js
@@ -180,9 +180,10 @@ class RunService {
     async update(identifier, payload) {
         const { runPatch = {}, relations = {}, metadata = {} } = payload;
         const { tagsTexts = null, eorReasons = null, runTypeName = null,
-            userIdentifier = {}, detectorsQualities = [], lhcPeriodName = null,
+            userIdentifier = {}, detectorsQualities = [],
             userO2Start = null, userO2Stop = null } = relations;
 
+        const { lhcPeriod } = runPatch;
         const tags = tagsTexts ? await getAllTagsByTextOrFail(tagsTexts, true) : null;
 
         if (runTypeName) {
@@ -190,9 +191,9 @@ class RunService {
             runPatch.runTypeId = runType.id;
         }
 
-        if (lhcPeriodName) {
-            const lhcPeriod = await getOrCreateLhcPeriod({ name: lhcPeriodName });
-            runPatch.lhcPeriodId = lhcPeriod.id;
+        if (lhcPeriod?.name) {
+            const lhcPeriodEntity = await getOrCreateLhcPeriod({ name: lhcPeriod.name });
+            runPatch.lhcPeriodId = lhcPeriodEntity.id;
         }
 
         let user = null;


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- At the first SB today, we have observed an issue in which lhcPeriodName was not being saved in Bookkeeping

Notable changes for developers:
- this was due to the lhcPeriod string from ECS being extracted from relations instead of patch which resulted in a null lhcPeriod being saved

Changes made to the database:
-
