### PR TITLE
Remove spurious detectors from Runs views

### DIFF
--- a/lib/public/views/Runs/ActiveColumns/runDetectorsAsyncQcActiveColumns.js
+++ b/lib/public/views/Runs/ActiveColumns/runDetectorsAsyncQcActiveColumns.js
@@ -31,6 +31,11 @@ export const createRunDetectorsAsyncQcActiveColumns = (dplDetectors, { profiles,
                 if (dataPassId && simulationPassId) {
                     throw new Error('`dataPassId` are `simulationPassId` are exclusive options');
                 }
+
+                const detectorWasActiveDuringRun = Boolean(run.detectorsQualities.find(({ name }) => name === detectorName));
+                if (!detectorWasActiveDuringRun) {
+                    return null;
+                }
                 const detectorQualityDisplay = h('.btn.white.bg-primary', 'QC');
 
                 if (dataPassId) {

--- a/test/public/runs/runsPerDataPass.overview.test.js
+++ b/test/public/runs/runsPerDataPass.overview.test.js
@@ -96,7 +96,7 @@ module.exports = () => {
             timeTrgEnd: (date) => !isNaN(Date.parse(date)),
             aliceL3Current: (current) => !isNaN(Number(current)),
             aliceL3Dipole: (current) => !isNaN(Number(current)),
-            ...Object.fromEntries(DETECTORS.map((detectorName) => [detectorName, (quality) => expect(quality).to.be.equal('QC')])),
+            ...Object.fromEntries(DETECTORS.map((detectorName) => [detectorName, (quality) => expect(quality).to.be.oneOf(['QC', ''])])),
         };
 
         // We find the headers matching the datatype keys

--- a/test/public/runs/runsPerSimulationPass.overview.test.js
+++ b/test/public/runs/runsPerSimulationPass.overview.test.js
@@ -97,7 +97,7 @@ module.exports = () => {
 
             aliceL3Current: (current) => !isNaN(Number(current.replace(/,/g, ''))),
             dipoleCurrent: (current) => !isNaN(Number(current.replace(/,/g, ''))),
-            ...Object.fromEntries(DETECTORS.map((detectorName) => [detectorName, (quality) => expect(quality).to.be.equal('QC')])),
+            ...Object.fromEntries(DETECTORS.map((detectorName) => [detectorName, (quality) => expect(quality).to.be.oneOf(['QC', ''])])),
         };
 
         await validateTableData(page, new Map(Object.entries(tableDataValidators)));


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- Removed spurious detectors from Runs Per Data Pass and Runs Per Simulation Pass pages

Notable changes for developers:
- NA

Changes made to the database:
- NA
