### PR TITLE
[O2B-1255] Disable a QC flag delete button when the flag is verified

### DIFF
--- a/lib/public/views/QcFlags/details/qcFlagDetailsComponent.js
+++ b/lib/public/views/QcFlags/details/qcFlagDetailsComponent.js
@@ -105,7 +105,12 @@ export const qcFlagDetailsComponenet = (qcFlagDetailsModel, additionalDetailsCon
                     Loading: () => deleteButton(null, 'Processing...'),
                     Success: () => deleteButton(null, 'Processed!'),
                     Failure: () => deleteButton(() => qcFlagDetailsModel.delete()),
-                    NotAsked: () => deleteButton(() => qcFlagDetailsModel.delete()),
+                    NotAsked: () => remoteQcFlag.match({
+                        Success: (qcFlag) => qcFlag.verifications?.length > 0
+                            ? tooltip(deleteButton(), 'Cannot delete verified flag')
+                            : deleteButton(() => qcFlagDetailsModel.delete()),
+                        Other: () => deleteButton(),
+                    }),
                 })),
             ]),
         ]),


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- Disabled QC flag delete button for verified flags

Notable changes for developers:
- NA

Changes made to the database:
- NA
