### PR TITLE
[O2B-1254] Confirmation when deleting QC flag

### DIFF
--- a/lib/public/views/QcFlags/details/qcFlagDetailsComponent.js
+++ b/lib/public/views/QcFlags/details/qcFlagDetailsComponent.js
@@ -96,6 +96,8 @@ export const qcFlagDetailsComponenet = (qcFlagDetailsModel, additionalDetailsCon
         verificationCreationModel,
     } = qcFlagDetailsModel;
 
+    const deleteConfirmationMessage = 'Are you sure you want to delete the QC flag?';
+
     return h('', [
         h('.flex-row.justify-between.items-center', [
             h('h2', 'QC Flag Details'),
@@ -104,8 +106,16 @@ export const qcFlagDetailsComponenet = (qcFlagDetailsModel, additionalDetailsCon
                 sessionService.hasAccess(BkpRoles.ADMIN) && h('.pv3', deleteResult.match({
                     Loading: () => deleteButton(null, 'Processing...'),
                     Success: () => deleteButton(null, 'Processed!'),
-                    Failure: () => deleteButton(() => qcFlagDetailsModel.delete()),
-                    NotAsked: () => deleteButton(() => qcFlagDetailsModel.delete()),
+                    Failure: () => deleteButton(() => {
+                        if (confirm(deleteConfirmationMessage)) {
+                            qcFlagDetailsModel.delete();
+                        }
+                    }),
+                    NotAsked: () => deleteButton(() => {
+                        if (confirm(deleteConfirmationMessage)) {
+                            qcFlagDetailsModel.delete();
+                        }
+                    }),
                 })),
             ]),
         ]),

--- a/test/public/qcFlags/detailsForDataPass.test.js
+++ b/test/public/qcFlags/detailsForDataPass.test.js
@@ -111,6 +111,7 @@ module.exports = () => {
         } });
 
         await validateElement(page, 'button#delete');
+        page.on('dialog', (dialog) => dialog.accept());
         await waitForNavigation(page, () => pressElement(page, 'button#delete'));
         expect(await checkMismatchingUrlParam(page, {
             page: 'qc-flags-for-data-pass',

--- a/test/public/qcFlags/detailsForSimulationPass.test.js
+++ b/test/public/qcFlags/detailsForSimulationPass.test.js
@@ -111,6 +111,7 @@ module.exports = () => {
         } });
 
         await validateElement(page, 'button#delete');
+        page.on('dialog', (dialog) => dialog.accept());
         await waitForNavigation(page, () => pressElement(page, 'button#delete'));
         expect(await checkMismatchingUrlParam(page, {
             page: 'qc-flags-for-simulation-pass',


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- Added browser confirmation when deleting QC flag

Notable changes for developers:
- NA

Changes made to the database:
- NA
