### PR TITLE
[O2B-1270] Fix environment update gRPC API

### DIFF
--- a/lib/database/adapters/RunAdapter.js
+++ b/lib/database/adapters/RunAdapter.js
@@ -328,6 +328,27 @@ class RunAdapter {
             runNumber: databaseObject.runNumber,
         };
     }
+
+    /**
+     * Converts a run entity to a gRPC run message
+     *
+     * @param {Run} run the run to convert to gRPC
+     * @return {Object} the run message
+     */
+    toGRPC(run) {
+        // The gRPC proto expect a list of detectors, do the conversion
+        const detectors = run.detectors?.split(',')?.map((detector) => detector.trim());
+        // The proto expect the run type name and not the run type related entity
+        const runType = run.runType?.name ?? undefined;
+        const { lhcPeriod } = run;
+
+        return {
+            ...run,
+            detectors,
+            runType,
+            lhcPeriod: lhcPeriod?.name,
+        };
+    }
 }
 
 exports.RunAdapter = RunAdapter;

--- a/lib/server/controllers/gRPC/GRPCEnvironmentController.js
+++ b/lib/server/controllers/gRPC/GRPCEnvironmentController.js
@@ -12,6 +12,7 @@
  */
 
 const { environmentService } = require('../../services/environment/EnvironmentService.js');
+const { runAdapter } = require('../../../database/adapters/index');
 
 /**
  * Controller to handle requests through gRPC EnvironmentService
@@ -22,6 +23,7 @@ class GRPCEnvironmentController {
      */
     constructor() {
         this.environmentService = environmentService;
+        this.runAdapter = runAdapter;
     }
 
     // eslint-disable-next-line require-jsdoc
@@ -33,7 +35,13 @@ class GRPCEnvironmentController {
     // eslint-disable-next-line require-jsdoc
     async Update(environmentPatch) {
         const { id: environmentId, toredownAt, status, statusMessage } = environmentPatch;
-        return this.environmentService.update(environmentId, { toredownAt: Number(toredownAt) }, { status, statusMessage });
+
+        const updatedEnvironment = await this.environmentService.update(environmentId, { toredownAt: Number(toredownAt) }, { status, statusMessage });
+
+        return {
+            ...updatedEnvironment,
+            runs: updatedEnvironment.runs ? updatedEnvironment.runs.map((run) => this.runAdapter.toGRPC(run)) : updatedEnvironment.runs,
+        };
     }
 }
 

--- a/lib/server/controllers/gRPC/GRPCEnvironmentController.js
+++ b/lib/server/controllers/gRPC/GRPCEnvironmentController.js
@@ -36,7 +36,11 @@ class GRPCEnvironmentController {
     async Update(environmentPatch) {
         const { id: environmentId, toredownAt, status, statusMessage } = environmentPatch;
 
-        const updatedEnvironment = await this.environmentService.update(environmentId, { toredownAt: Number(toredownAt) }, { status, statusMessage });
+        const updatedEnvironment = await this.environmentService.update(
+            environmentId,
+            { toredownAt: Number(toredownAt) },
+            { status, statusMessage },
+        );
 
         return {
             ...updatedEnvironment,

--- a/lib/server/controllers/gRPC/GRPCRunController.js
+++ b/lib/server/controllers/gRPC/GRPCRunController.js
@@ -12,6 +12,7 @@
  */
 
 const { runService } = require('../../services/run/RunService.js');
+const { runAdapter } = require('../../../database/adapters/index');
 
 /**
  * Controller to handle requests through gRPC RunService
@@ -22,6 +23,7 @@ class GRPCRunController {
      */
     constructor() {
         this.runService = runService;
+        this.runAdapter = runAdapter;
     }
 
     // eslint-disable-next-line require-jsdoc
@@ -29,14 +31,14 @@ class GRPCRunController {
         const run = await this.runService.getOrFail({ runNumber }, { lhcFill: relations.includes('LHC_FILL') });
         const { lhcFill } = run;
         delete run.lhcFill;
-        return { run: this.runToGRPC(run), lhcFill };
+        return { run: this.runAdapter.toGRPC(run), lhcFill };
     }
 
     // eslint-disable-next-line require-jsdoc
     async Create(newRunRequest) {
         const { run, relations } = this.gRPCToRunAndRelations(newRunRequest);
 
-        return this.runToGRPC(await this.runService.create(
+        return this.runAdapter.toGRPC(await this.runService.create(
             run,
             {
                 runTypeName: relations.runType?.name,
@@ -52,7 +54,7 @@ class GRPCRunController {
         const { runNumber } = run;
         delete run.runNumber;
 
-        return this.runToGRPC(await this.runService.update(
+        return this.runAdapter.toGRPC(await this.runService.update(
             { runNumber },
             {
                 runPatch: run,
@@ -65,27 +67,6 @@ class GRPCRunController {
                 },
             },
         ));
-    }
-
-    /**
-     * Converts a run entity to a gRPC run message
-     *
-     * @param {Run} run the run to convert to gRPC
-     * @return {Object} the run message
-     */
-    runToGRPC(run) {
-        // The gRPC proto expect a list of detectors, do the conversion
-        const detectors = run.detectors?.split(',')?.map((detector) => detector.trim());
-        // The proto expect the run type name and not the run type related entity
-        const runType = run.runType?.name ?? undefined;
-        const { lhcPeriod } = run;
-
-        return {
-            ...run,
-            detectors,
-            runType,
-            lhcPeriod: lhcPeriod?.name,
-        };
     }
 
     /**

--- a/lib/server/services/environment/EnvironmentService.js
+++ b/lib/server/services/environment/EnvironmentService.js
@@ -112,13 +112,16 @@ class EnvironmentService {
     _getEnvironmentQbConfiguration(queryBuilder) {
         queryBuilder.include({
             association: 'runs',
-            include: {
-                association: 'eorReasons',
-                include: {
-                    association: 'reasonType',
-                    attributes: ['category', 'title'],
+            include: [
+                {
+                    association: 'eorReasons',
+                    include: {
+                        association: 'reasonType',
+                        attributes: ['category', 'title'],
+                    },
                 },
-            },
+                'runType',
+            ],
         });
         queryBuilder.include('historyItems');
     }


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Previously, runs were not parsed (because repeated field in environment proto) and were returned as is in gRPC response. After https://github.com/AliceO2Group/Bookkeeping/pull/1569 the enums of runs are converted from their js value (string expression of enum) to their gRPC counterpart. The issue is that runType in environments were `runTypeId` which made the enums conversion to fail. 

Notable changes for users:
- Fixed the error thrown when updating environment through gRPC API
