### PR TITLE
Ignore eslint major upgrade in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,8 @@ updates:
   ignore:
     - dependency-name: "*"
       update-types: ["version-update:semver-patch"]
+    - dependency-name: "eslint"
+      update-types: ["version-update:semver-major"]
     - dependency-name: "chai"
       update-types: ["version-update:semver-major"]
   reviewers:


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [X] explain what this PR does

Notable changes for developers:
- Dependabot will not create PRs to update eslint to 9.x
