### PR TITLE
[O2B-1041] Display fill efficiency with 2 decimals in statistics tooltip

### DIFF
--- a/lib/public/views/Statistics/charts/efficiencyChartComponent.js
+++ b/lib/public/views/Statistics/charts/efficiencyChartComponent.js
@@ -57,7 +57,7 @@ export const efficiencyChartComponent = (statistics, onPointHover, periodLabel) 
                 h('h5', `Fill #${x}`),
                 h('.flex-row.items-center.g2', [
                     h('.tooltip-bullet', { style: `background-color: ${ChartColors.Blue.dark}` }),
-                    h('', `Efficiency: ${formatPercentage(y[1], 0)}`),
+                    h('', `Efficiency: ${formatPercentage(y[1], 2)}`),
                 ]),
                 h('.flex-row.items-center.g2', [
                     h('.tooltip-bullet', { style: `background-color: ${ChartColors.Red.dark}` }),


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- Fill efficiency is rounded to 2 decimals in statistics tooltip
