### PR TITLE
[O2B-1333] Restrict setting GAQ detectors to 'gaq' role

### DIFF
--- a/lib/domain/enums/BkpRoles.js
+++ b/lib/domain/enums/BkpRoles.js
@@ -14,4 +14,5 @@
 exports.BkpRoles = Object.freeze({
     ADMIN: 'admin',
     GUEST: 'guest',
+    GAQ: 'gaq',
 });

--- a/lib/public/domain/enums/BkpRoles.js
+++ b/lib/public/domain/enums/BkpRoles.js
@@ -14,4 +14,5 @@
 export const BkpRoles = Object.freeze({
     ADMIN: 'admin',
     GUEST: 'guest',
+    GAQ: 'gaq',
 });

--- a/lib/server/controllers/dataPasses.controller.js
+++ b/lib/server/controllers/dataPasses.controller.js
@@ -77,7 +77,11 @@ const setGaqDetectors = async (req, res) => {
                 dplDetectorIds,
             } = validatedDTO.body;
 
-            const data = await dataPassService.setGaqDetectors(dataPassId, runNumbers, dplDetectorIds);
+            const user = {
+                roles: validatedDTO.session.access,
+            };
+
+            const data = await dataPassService.setGaqDetectors(dataPassId, runNumbers, dplDetectorIds, { user });
             res.status(201).json({ data });
         } catch (error) {
             updateExpressResponseFromNativeError(res, error);

--- a/lib/server/services/dataPasses/DataPassService.js
+++ b/lib/server/services/dataPasses/DataPassService.js
@@ -19,12 +19,26 @@ const { DataPassVersionRepository, GaqDetectorRepository, RunRepository, DplDete
 const { getOneDataPass } = require('./getOneDataPass.js');
 const { getOneDataPassOrFail } = require('./getOneDataPassOrFail.js');
 const { BadParameterError } = require('../../errors/BadParameterError');
+const { AccessDeniedError } = require('../../errors/AccessDeniedError');
+const { BkpRoles } = require('../../../domain/enums/BkpRoles');
 
 /**
  * @typedef DataPassIdentifier
  * @param {number} [id]
  * @param {string} [name]
  */
+
+/**
+ * Check whether given user's roles suffice to manage GAQ detectors
+ * @param {string[]} userRoles roles of user
+ * @return {void}
+ * @throws {AccessDeniedError} when roles doesn't suffice
+ */
+const validateUserGaqAccess = (userRoles) => {
+    if (!userRoles.includes(BkpRoles.ADMIN) && !userRoles.includes(BkpRoles.GAQ)) {
+        throw new AccessDeniedError('You have no permission to manage GAQ detector');
+    }
+};
 
 /**
  * Data Pass Service
@@ -73,9 +87,14 @@ class DataPassService {
      * @param {number} dataPassId data pass id
      * @param {number[]} runNumbers list of run numbers
      * @param {number[]} detectorIds list of ids of DPL detectors included in GAQ computation for the given runs and datapass
+     * @param {object} relations relations of the QC flag
+     * @param {UserWithRoles} relations.user identifier with roles of the user creating the QC flag
      * @return {Promise<void>} promise resolved once association between data pass, runs and detectors was set
      */
-    setGaqDetectors(dataPassId, runNumbers, detectorIds) {
+    setGaqDetectors(dataPassId, runNumbers, detectorIds, relations) {
+        const { user: { roles: userRoles = [] } } = relations;
+        validateUserGaqAccess(userRoles);
+
         return dataSource.transaction(async () => {
             await getOneDataPassOrFail({ id: dataPassId });
             await this._verifyDataPassAndRunsAssociation(dataPassId, runNumbers);
@@ -140,7 +159,7 @@ class DataPassService {
      * As there is no direct link between runs and DPL detectors,
      *  association between run and corresponding Detector (with same name as DPL Detector) is checked
      *
-     * @param {number[]} runNumbers list of run numbers
+     * @param {number[]} runNumbers list of run numbers0
      * @param {number[]} detectorIds list of IDs of DPL detectors
      * @return {Promise<void>} promise resolved once associations are validated
      * @throws {BadParameterError} if some association does not exist

--- a/test/api/dataPasses.test.js
+++ b/test/api/dataPasses.test.js
@@ -16,6 +16,7 @@ const request = require('supertest');
 const { server } = require('../../lib/application');
 const { resetDatabaseContent } = require('../utilities/resetDatabaseContent.js');
 const { DetectorType } = require('../../lib/domain/enums/DetectorTypes');
+const { BkpRoles } = require('../../lib/domain/enums/BkpRoles');
 
 const LHC22b_apass1 = {
     id: 1,
@@ -315,7 +316,7 @@ module.exports = () => {
             const dataPassId = 3;
             const runNumbers = [49, 56];
             const detectorIds = [4, 7];
-            const response = await request(server).post('/api/dataPasses/gaqDetectors').send({
+            const response = await request(server).post(`/api/dataPasses/gaqDetectors?token=${BkpRoles.GAQ}`).send({
                 dataPassId,
                 runNumbers,
                 dplDetectorIds: detectorIds,

--- a/test/lib/server/services/dataPasses/DataPassService.test.js
+++ b/test/lib/server/services/dataPasses/DataPassService.test.js
@@ -18,6 +18,7 @@ const { NotFoundError } = require('../../../../../lib/server/errors/NotFoundErro
 const { dataPassService } = require('../../../../../lib/server/services/dataPasses/DataPassService.js');
 const { BadParameterError } = require('../../../../../lib/server/errors/BadParameterError.js');
 const { DetectorType } = require('../../../../../lib/domain/enums/DetectorTypes.js');
+const { BkpRoles } = require('../../../../../lib/domain/enums/BkpRoles.js');
 
 const LHC22b_apass1 = {
     id: 1,
@@ -176,20 +177,27 @@ module.exports = () => {
         it('should successfuly set GAQ detectors', async () => {
             const runNumbers = [49, 56];
             const detectorIds = [4, 7];
-            const data = await dataPassService.setGaqDetectors(dataPassId, runNumbers, detectorIds);
+            const data = await dataPassService.setGaqDetectors(dataPassId, runNumbers, detectorIds, { user: { roles: [BkpRoles.GAQ] } });
             expect(data).to.be.have.all.deep.members(runNumbers
                 .flatMap((runNumber) => detectorIds.map((detectorId) => ({ dataPassId, runNumber, detectorId }))));
         });
         it('should fail to set GAQ detectors because of miaaing association', async () => {
             let errorMessage = `No association between data pass with id ${dataPassId} and following runs: 1`;
             assert.rejects(
-                () => dataPassService.setGaqDetectors(dataPassId, [1], [4]),
+                () => dataPassService.setGaqDetectors(dataPassId, [1], [4], { user: { roles: [BkpRoles.GAQ] } }),
                 new BadParameterError(errorMessage),
             );
             errorMessage = `No association between runs and detectors: ${JSON.stringify([[56, 'CPV']])}`;
             assert.rejects(
                 () => dataPassService.setGaqDetectors(dataPassId, [105, 56], [1]),
                 new BadParameterError(errorMessage),
+            );
+        });
+
+        it('should fail to set GAQ detectors because of insufficient permission', async () => {
+            assert.rejects(
+                () => dataPassService.setGaqDetectors(dataPassId, [1], [4], { user: { roles: [BkpRoles.GUEST] } }),
+                new BadParameterError('You have no permission to manage GAQ detector'),
             );
         });
 


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- NA

Notable changes for developers:
- Restricted setting GAQ detectors to 'gaq' role

Changes made to the database:
- NA
