### PR TITLE
[O2B-1364] Fix unnecessary splitting of GAQ periods

### DIFF
--- a/lib/database/repositories/QcFlagRepository.js
+++ b/lib/database/repositories/QcFlagRepository.js
@@ -32,10 +32,8 @@ const GAQ_PERIODS_VIEW = `
                         gaqd.run_number,
                         COALESCE(UNIX_TIMESTAMP(qcfep.\`from\`), 0) AS timestamp
                     FROM quality_control_flag_effective_periods AS qcfep
-                        INNER JOIN quality_control_flags AS qcf
-                            ON qcf.id = qcfep.flag_id
-                        INNER JOIN data_pass_quality_control_flag AS dpqcf
-                            ON dpqcf.quality_control_flag_id = qcf.id
+                        INNER JOIN quality_control_flags AS qcf ON qcf.id = qcfep.flag_id
+                        INNER JOIN data_pass_quality_control_flag AS dpqcf ON dpqcf.quality_control_flag_id = qcf.id
                         INNER JOIN global_aggregated_quality_detectors AS gaqd
                             ON gaqd.data_pass_id = dpqcf.data_pass_id
                             AND gaqd.run_number = qcf.run_number
@@ -47,10 +45,8 @@ const GAQ_PERIODS_VIEW = `
                         gaqd.run_number,
                         UNIX_TIMESTAMP(COALESCE(qcfep.\`to\`, NOW())) AS timestamp
                     FROM quality_control_flag_effective_periods AS qcfep
-                        INNER JOIN quality_control_flags AS qcf
-                            ON qcf.id = qcfep.flag_id
-                        INNER JOIN data_pass_quality_control_flag AS dpqcf
-                            ON dpqcf.quality_control_flag_id = qcf.id
+                        INNER JOIN quality_control_flags AS qcf ON qcf.id = qcfep.flag_id
+                        INNER JOIN data_pass_quality_control_flag AS dpqcf ON dpqcf.quality_control_flag_id = qcf.id
                         INNER JOIN global_aggregated_quality_detectors AS gaqd
                             ON gaqd.data_pass_id = dpqcf.data_pass_id
                             AND gaqd.run_number = qcf.run_number

--- a/lib/database/repositories/QcFlagRepository.js
+++ b/lib/database/repositories/QcFlagRepository.js
@@ -34,6 +34,8 @@ const GAQ_PERIODS_VIEW = `
                     FROM quality_control_flag_effective_periods AS qcfep
                         INNER JOIN quality_control_flags AS qcf ON qcf.id = qcfep.flag_id
                         INNER JOIN data_pass_quality_control_flag AS dpqcf ON dpqcf.quality_control_flag_id = qcf.id
+                        -- Only flags of detectors which are defined in global_aggregated_quality_detectors
+                        -- should be taken into account for calculation of gaq_effective_periods
                         INNER JOIN global_aggregated_quality_detectors AS gaqd
                             ON gaqd.data_pass_id = dpqcf.data_pass_id
                             AND gaqd.run_number = qcf.run_number
@@ -47,6 +49,8 @@ const GAQ_PERIODS_VIEW = `
                     FROM quality_control_flag_effective_periods AS qcfep
                         INNER JOIN quality_control_flags AS qcf ON qcf.id = qcfep.flag_id
                         INNER JOIN data_pass_quality_control_flag AS dpqcf ON dpqcf.quality_control_flag_id = qcf.id
+                        -- Only flags of detectors which are defined in global_aggregated_quality_detectors
+                        -- should be taken into account for calculation of gaq_effective_periods
                         INNER JOIN global_aggregated_quality_detectors AS gaqd
                             ON gaqd.data_pass_id = dpqcf.data_pass_id
                             AND gaqd.run_number = qcf.run_number

--- a/lib/database/repositories/QcFlagRepository.js
+++ b/lib/database/repositories/QcFlagRepository.js
@@ -32,8 +32,14 @@ const GAQ_PERIODS_VIEW = `
                         run_number,
                         COALESCE(UNIX_TIMESTAMP(qcfep.\`from\`), 0) AS timestamp
                     FROM quality_control_flag_effective_periods AS qcfep
-                        INNER JOIN quality_control_flags AS qcf ON qcf.id = qcfep.flag_id
-                        INNER JOIN data_pass_quality_control_flag AS dpqcf ON dpqcf.quality_control_flag_id = qcf.id
+                        INNER JOIN quality_control_flags AS qcf
+                            ON qcf.id = qcfep.flag_id
+                        INNER JOIN data_pass_quality_control_flag AS dpqcf
+                            ON dpqcf.quality_control_flag_id = qcf.id
+                        INNER JOIN global_aggregated_quality_detectors AS gaqd
+                            ON gaqd.data_pass_id = dpqcf.data_pass_id
+                            AND gaqd.run_number = qcf.run_number
+                            AND gaqd.detector_id = qcf.detector_id
                 )
                 UNION
                 (
@@ -41,8 +47,14 @@ const GAQ_PERIODS_VIEW = `
                         run_number,
                         UNIX_TIMESTAMP(COALESCE(qcfep.\`to\`, NOW())) AS timestamp
                     FROM quality_control_flag_effective_periods AS qcfep
-                        INNER JOIN quality_control_flags AS qcf ON qcf.id = qcfep.flag_id
-                        INNER JOIN data_pass_quality_control_flag AS dpqcf ON dpqcf.quality_control_flag_id = qcf.id
+                        INNER JOIN quality_control_flags AS qcf
+                            ON qcf.id = qcfep.flag_id
+                        INNER JOIN data_pass_quality_control_flag AS dpqcf
+                            ON dpqcf.quality_control_flag_id = qcf.id
+                        INNER JOIN global_aggregated_quality_detectors AS gaqd
+                            ON gaqd.data_pass_id = dpqcf.data_pass_id
+                            AND gaqd.run_number = qcf.run_number
+                            AND gaqd.detector_id = qcf.detector_id
                 )
                 ORDER BY timestamp
             ) AS ap

--- a/lib/database/repositories/QcFlagRepository.js
+++ b/lib/database/repositories/QcFlagRepository.js
@@ -28,8 +28,8 @@ const GAQ_PERIODS_VIEW = `
             ) AS \`to\`
         FROM (
                 (
-                    SELECT data_pass_id,
-                        run_number,
+                    SELECT gaqd.data_pass_id,
+                        gaqd.run_number,
                         COALESCE(UNIX_TIMESTAMP(qcfep.\`from\`), 0) AS timestamp
                     FROM quality_control_flag_effective_periods AS qcfep
                         INNER JOIN quality_control_flags AS qcf
@@ -43,8 +43,8 @@ const GAQ_PERIODS_VIEW = `
                 )
                 UNION
                 (
-                    SELECT data_pass_id,
-                        run_number,
+                    SELECT gaqd.data_pass_id,
+                        gaqd.run_number,
                         UNIX_TIMESTAMP(COALESCE(qcfep.\`to\`, NOW())) AS timestamp
                     FROM quality_control_flag_effective_periods AS qcfep
                         INNER JOIN quality_control_flags AS qcf

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "sequelize": "sequelize-cli",
     "start:dev": "nodemon --ignore 'lib/public/**/*.js' lib/main.js",
     "start:prod": "node lib/main.js",
-    "test": "mocha --exit --timeout 0 --grep 'QcFlagService|QcFlags API'",
+    "test": "mocha --exit --timeout 0",
     "test:subset": "nyc -- mocha --exit --timeout 0 test/scripts/test-${TEST_TYPE}.js && nyc report --report-dir=/usr/src/app/coverage/${TEST_TYPE} --reporter=json",
     "test:subset-local": "mocha --exit --timeout 0 --reporter test/scripts/parallel-local/custom-mocha-reporter.js test/scripts/test-${TEST_TYPE}.js",
     "docker-run": "docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "sequelize": "sequelize-cli",
     "start:dev": "nodemon --ignore 'lib/public/**/*.js' lib/main.js",
     "start:prod": "node lib/main.js",
-    "test": "mocha --exit --timeout 0",
+    "test": "mocha --exit --timeout 0 --grep 'QcFlagService|QcFlags API'",
     "test:subset": "nyc -- mocha --exit --timeout 0 test/scripts/test-${TEST_TYPE}.js && nyc report --report-dir=/usr/src/app/coverage/${TEST_TYPE} --reporter=json",
     "test:subset-local": "mocha --exit --timeout 0 --reporter test/scripts/parallel-local/custom-mocha-reporter.js test/scripts/test-${TEST_TYPE}.js",
     "docker-run": "docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build",


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- Fixed unnecessary splitting of GAQ periods

Notable changes for developers:
- Fixed calculation of timestamps which define gaq_effective_periods, so only flags of detectors which are defined in global_aggregated_quality_detectors are taken into account for the calculation

Changes made to the database:
- NA
