### PR TITLE
[O2B-1315] Disable ECS Kafka messages consumption by default

### DIFF
--- a/lib/config/kafka.js
+++ b/lib/config/kafka.js
@@ -13,7 +13,7 @@
 
 // Default configuration
 const brokers = process.env?.KAFKA_BROKER ? [process.env.KAFKA_BROKER] : null;
-const consumeEcsMessages = process.env?.CONSUME_ECS_MESSAGES?.toLowerCase() === 'true';
+const consumeEcsMessages = process.env?.CONSUME_ECS_MESSAGES?.toLowerCase() === 'false';
 
 module.exports = {
     brokers,


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for developers:
- ECS kafka messages consumption is disabled by default
