### PR TITLE
[O2B-1265] Make info from previous shifter readonly

### DIFF
--- a/lib/domain/dtos/eosReport/CreateEosReportDto.js
+++ b/lib/domain/dtos/eosReport/CreateEosReportDto.js
@@ -81,7 +81,6 @@ const CreateEosReportDto = Joi.object({
                 },
             ],
         }).required(),
-        infoFromPreviousShifter: Joi.string().allow('').optional(),
         infoForNextShifter: Joi.string().allow('').optional(),
         infoForRmRc: Joi.string().allow('').optional(),
     },

--- a/lib/public/views/EosReport/create/EosReportCreationModel.js
+++ b/lib/public/views/EosReport/create/EosReportCreationModel.js
@@ -126,6 +126,9 @@ export class EosReportCreationModel extends CreationModel {
             ...this.data,
         };
 
+        // Delete the infoFromPreviousShifter field from the ret object since it's display only
+        delete ret.infoFromPreviousShifter;
+
         // Data processing specific to some EoS report types
         switch (this._reportType) {
             case ShiftTypes.SL:

--- a/lib/public/views/EosReport/create/eosReportCreationComponent.js
+++ b/lib/public/views/EosReport/create/eosReportCreationComponent.js
@@ -12,7 +12,7 @@
  */
 
 import { h, switchCase } from '/js/src/index.js';
-import { markdownInput } from '../../../components/common/markdown/markdown.js';
+import { markdownDisplay, markdownInput } from '../../../components/common/markdown/markdown.js';
 import spinner from '../../../components/common/spinner.js';
 import { frontLink } from '../../../components/common/navigation/frontLink.js';
 import { creationFormComponent } from '../../../components/common/form/creationFormComponent.js';
@@ -103,12 +103,9 @@ const eosReportCreationForm = (reportType, formData, shiftData) => [
             formData.infoFromPreviousShifter && !shiftData.infoFromPreviousShifter.errorMessage
                 ? h('.f7', contextualInfo('Automatically filled using previous EoS report'))
                 : h('.f7', contextualWarning(shiftData.infoFromPreviousShifter.errorMessage || '')),
-            markdownInput(
+            markdownDisplay(
                 formData.infoFromPreviousShifter,
-                {
-                    // eslint-disable-next-line no-return-assign
-                    oninput: (e) => formData.infoFromPreviousShifter = e.target.value,
-                },
+                {},
                 { height: '10rem' },
             ),
         ]),

--- a/lib/server/services/eosReport/EosReportService.js
+++ b/lib/server/services/eosReport/EosReportService.js
@@ -113,7 +113,6 @@ class EosReportService {
             issuesLogEntries: shiftIssues,
             lhcTransitions: reportCreationRequest.lhcTransitions,
             shiftFlow: reportCreationRequest.shiftFlow,
-            infoFromPreviousShifter: reportCreationRequest.infoFromPreviousShifter,
             infoForNextShifter: reportCreationRequest.infoForNextShifter,
             infoForRmRc: reportCreationRequest.infoForRmRc,
         };


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [ ] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- the info from previous shifter field in eos report creation is now readonly
