### PR TITLE
Start docker compose in detached mode

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -23,7 +23,18 @@ Use the npm script (the `docker compose` command must be available to npm)
 npm run docker-run
 ```
 
-You will then see in these tabs the server's log
+The docker stack will start to run in the background. If you want to see the logs run, from the directory where docker
+has been started:
+
+```sh
+docker compose logs -f
+```
+
+And finally, if you want to stop the docker stack simply run, from the directory where docker has been started:
+
+```sh
+docker compose stop
+```
 
 ### Run seeders
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "mocha --exit --timeout 0",
     "test:subset": "nyc -- mocha --exit --timeout 0 test/scripts/test-${TEST_TYPE}.js && nyc report --report-dir=/usr/src/app/coverage/${TEST_TYPE} --reporter=json",
     "test:subset-local": "mocha --exit --timeout 0 --reporter test/scripts/parallel-local/custom-mocha-reporter.js test/scripts/test-${TEST_TYPE}.js",
-    "docker-run": "docker compose -d -f docker-compose.yml -f docker-compose.dev.yml up --build",
+    "docker-run": "docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build -d",
     "docker-test": "docker compose -p test -f docker-compose.yml -f docker-compose.test.yml up --build --abort-on-container-exit",
     "docker-test:parallel": "node test/scripts/parallel-local/main.js",
     "docker-update": "node scripts/update-dockerfile.js"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "mocha --exit --timeout 0",
     "test:subset": "nyc -- mocha --exit --timeout 0 test/scripts/test-${TEST_TYPE}.js && nyc report --report-dir=/usr/src/app/coverage/${TEST_TYPE} --reporter=json",
     "test:subset-local": "mocha --exit --timeout 0 --reporter test/scripts/parallel-local/custom-mocha-reporter.js test/scripts/test-${TEST_TYPE}.js",
-    "docker-run": "docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build",
+    "docker-run": "docker compose -d -f docker-compose.yml -f docker-compose.dev.yml up --build",
     "docker-test": "docker compose -p test -f docker-compose.yml -f docker-compose.test.yml up --build --abort-on-container-exit",
     "docker-test:parallel": "node test/scripts/parallel-local/main.js",
     "docker-update": "node scripts/update-dockerfile.js"


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [X] explain what this PR does
- [X] if it is a new feature, explain how you plan to use it
- [X] documentation was updated or added

Notable changes for developers:
- Docker compose stack is now run in detached mode: this allow user to start docker stack from console without having to keep this console instance opened.
