### PR TITLE
[O2B-1387] Display lumi information on LHC fill details page

### DIFF
--- a/lib/database/seeders/20220503120937-lhc-fills.js
+++ b/lib/database/seeders/20220503120937-lhc-fills.js
@@ -62,10 +62,13 @@ module.exports = {
                     },
                     {
                         fill_number: 6,
+                        beam_type: 'PROTON-PROTON',
                         stable_beams_start: '2019-08-08 11:00:00',
                         stable_beams_end: '2019-08-08 23:00:00',
                         stable_beams_duration: 60 * 60 * 12,
                         filling_scheme_name: 'Single_12b_8_1024_8_2018',
+                        colliding_bunches_count: 123456789,
+                        delivered_luminosity: 420,
                         created_at: new Date('2019-08-09 21:00:00'),
                         updated_at: new Date('2019-08-09 21:00:00'),
                     },

--- a/lib/public/views/LhcFills/Detail/commonLhcFillDisplayConfiguration.js
+++ b/lib/public/views/LhcFills/Detail/commonLhcFillDisplayConfiguration.js
@@ -14,6 +14,7 @@
 import { frontLink } from '../../../components/common/navigation/frontLink.js';
 import { formatTimestamp } from '../../../utilities/formatting/formatTimestamp.js';
 import { formatDuration } from '../../../utilities/formatting/formatDuration.mjs';
+import { formatItemsCount } from '../../../utilities/formatting/formatItemsCount.js';
 
 /**
  * Display configuration of a given LHC fill
@@ -35,17 +36,27 @@ export const commonLhcFillDisplayConfiguration = [
             format: formatTimestamp,
         },
         stableBeamsDuration: {
-            name: 'Beams Duration',
+            name: 'Beams duration',
             // Duration is given in seconds, convert to milliseconds for display
             format: (duration) => formatDuration(1000 * duration),
         },
     },
     {
         beamType: {
-            name: 'Beam Type',
+            name: 'Beam type',
         },
         fillingSchemeName: {
             name: 'Scheme name',
+        },
+    },
+    {
+        collidingBunchesCount: {
+            name: 'Colliding bunches',
+            format: formatItemsCount,
+        },
+        deliveredLuminosity: {
+            name: 'Delivered lumi',
+            format: (luminosity) => luminosity ? `${luminosity} nb-1` : '-',
         },
     },
 ];

--- a/test/public/lhcFills/detail.test.js
+++ b/test/public/lhcFills/detail.test.js
@@ -38,6 +38,15 @@ module.exports = () => {
     it('should successfully display lhc fills details page', async () => {
         await goToPage(page, 'lhc-fill-details', { queryParameters: { fillNumber: 6 } });
         await expectInnerText(page, 'h2', 'Fill No. 6');
+
+        await expectInnerText(page, '#lhc-fill-stableBeamsStart', 'Stable beams start:\n08/08/2019, 11:00:00');
+        await expectInnerText(page, '#lhc-fill-stableBeamsEnd', 'Stable beams end:\n08/08/2019, 23:00:00');
+        await expectInnerText(page, '#lhc-fill-stableBeamsDuration', 'Beams duration:\n12:00:00');
+
+        await expectInnerText(page, '#lhc-fill-beamType', 'Beam type:\nPROTON-PROTON');
+        await expectInnerText(page, '#lhc-fill-fillingSchemeName', 'Scheme name:\nSingle_12b_8_1024_8_2018');
+        await expectInnerText(page, '#lhc-fill-collidingBunchesCount', 'Colliding bunches:\n123,456,789');
+        await expectInnerText(page, '#lhc-fill-deliveredLuminosity', 'Delivered lumi:\n420 nb-1');
     });
 
     it('should successfully emphasize the fills that have a stable beams', async () => {


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- Display colliding bunches and luminosity on fills details page

Notable changes for developers:
- N/A

Changes made to the database:
- N/A
