### PR TITLE
[O2B-1390] Fix grey QC summary

### DIFF
--- a/lib/server/services/qualityControlFlag/QcFlagService.js
+++ b/lib/server/services/qualityControlFlag/QcFlagService.js
@@ -321,11 +321,14 @@ class QcFlagService {
                     mcReproducible: Boolean(summaryDb.get('mcReproducible')),
                 }));
 
-        const s = new Set(runDetectorSummaryList.flatMap(({ flagIds }) => flagIds));
-        const verifiedFlagsIds = new Set((await QcFlagRepository.findAll({
+        const allFlagsIds = new Set(runDetectorSummaryList.flatMap(({ flagIds }) => flagIds));
+        const notVerifiedFlagsIds = new Set((await QcFlagRepository.findAll({
             attributes: ['id'],
-            include: [{ association: 'verifications', required: true, attributes: [] }],
-            where: { id: { [Op.in]: [...s] } },
+            include: [{ association: 'verifications', required: false, attributes: [] }],
+            where: {
+                id: { [Op.in]: [...allFlagsIds] },
+                '$verifications.id$': { [Op.is]: null },
+            },
         })).map(({ id }) => id));
 
         const summary = {};
@@ -337,7 +340,7 @@ class QcFlagService {
                 detectorId,
                 flagIds,
             } = runDetectorSummaryForFlagTypesClass;
-            const missingVerificationsCount = flagIds.filter((id) => !verifiedFlagsIds.has(id)).length;
+            const missingVerificationsCount = flagIds.filter((id) => notVerifiedFlagsIds.has(id)).length;
 
             if (!summary[runNumber]) {
                 summary[runNumber] = {};

--- a/lib/server/services/qualityControlFlag/QcFlagService.js
+++ b/lib/server/services/qualityControlFlag/QcFlagService.js
@@ -256,7 +256,6 @@ class QcFlagService {
         queryBuilder
             .include({ association: 'effectivePeriods', attributes: [], required: true })
             .include({ association: 'flagType', attributes: [] })
-            .include({ association: 'verifications', attributes: [] })
             .set('attributes', (sequelize) => [
                 'runNumber',
                 'detectorId',
@@ -297,8 +296,8 @@ class QcFlagService {
                     'effectiveRunCoverage',
                 ],
                 [
-                    sequelize.literal('COUNT( DISTINCT `QcFlag`.id ) - COUNT( DISTINCT `verifications`.flag_id )'),
-                    'missingVerificationsCount',
+                    sequelize.literal('GROUP_CONCAT( DISTINCT `QcFlag`.id )'),
+                    'flagIds',
                 ],
                 [
                     sequelize.literal('SUM( `flagType`.monte_carlo_reproducible ) > 0'),
@@ -318,9 +317,16 @@ class QcFlagService {
                     detectorId: summaryDb.detectorId,
                     effectiveRunCoverage: parseFloat(summaryDb.get('effectiveRunCoverage'), 10) || null,
                     bad: Boolean(summaryDb.get('bad')),
-                    missingVerificationsCount: parseInt(summaryDb.get('missingVerificationsCount'), 10),
+                    flagIds: (summaryDb.get('flagIds')?.split(',') ?? []).map((id) => parseInt(id, 10)),
                     mcReproducible: Boolean(summaryDb.get('mcReproducible')),
                 }));
+
+        const s = new Set(runDetectorSummaryList.flatMap(({ flagIds }) => flagIds));
+        const verifiedFlagsIds = new Set((await QcFlagRepository.findAll({
+            attributes: ['id'],
+            include: [{ association: 'verifications', required: true, attributes: [] }],
+            where: { id: { [Op.in]: [...s] } },
+        })).map(({ id }) => id));
 
         const summary = {};
 
@@ -329,8 +335,9 @@ class QcFlagService {
             const {
                 runNumber,
                 detectorId,
-                missingVerificationsCount,
+                flagIds,
             } = runDetectorSummaryForFlagTypesClass;
+            const missingVerificationsCount = flagIds.filter((id) => !verifiedFlagsIds.has(id)).length;
 
             if (!summary[runNumber]) {
                 summary[runNumber] = {};

--- a/test/lib/server/services/qualityControlFlag/QcFlagService.test.js
+++ b/test/lib/server/services/qualityControlFlag/QcFlagService.test.js
@@ -220,6 +220,20 @@ module.exports = () => {
 
             expect(goodCoverage / runDuration).to.be.equal(0);
             expect((badCoverage / runDuration).toFixed(4)).to.be.equal('0.0769');
+
+            // Verify flag and fetch summary one more time
+            const relations = { user: { roles: ['admin'], externalUserId: 456 } };
+            await qcFlagService.verifyFlag({ flagId: 4 }, relations);
+            expect(await qcFlagService.getQcFlagsSummary({ dataPassId })).to.be.eql({
+                1: {
+                    1: {
+                        missingVerificationsCount: 0,
+                        mcReproducible: false,
+                        badEffectiveRunCoverage: 0.0769,
+                        explicitlyNotBadEffectiveRunCoverage: 0,
+                    },
+                },
+            });
         });
 
         it('should successfully get empty QC flag summary for data pass', async () => {


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- Prevented the QC summary color from changing to gray after more than one verification 

Notable changes for developers:
- Added separate request to fetch non-verified flags when calculating QC summary

Changes made to the database:
- NA
