### PR TITLE
[O2B-1403] Add rct time start/end to runs

### DIFF
--- a/lib/database/migrations/20241212074001-create-rct-run-start-and-stop.js
+++ b/lib/database/migrations/20241212074001-create-rct-run-start-and-stop.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const ADD_RUN_RCT_START_AND_STOP = `
+    ALTER TABLE runs
+        ADD COLUMN rct_time_start DATETIME(3) AS (COALESCE(first_tf_timestamp, time_trg_start, time_o2_start)) VIRTUAL AFTER time_start,
+        ADD COLUMN rct_time_end   DATETIME(3) AS (COALESCE(last_tf_timestamp, time_trg_end, time_o2_end)) VIRTUAL AFTER rct_time_start;
+`;
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    up: async (queryInterface) => queryInterface.sequelize.query(ADD_RUN_RCT_START_AND_STOP),
+
+    down: async (queryInterface) => queryInterface.sequelize.transaction(async (transaction) => {
+        await queryInterface.removeColumn('runs', 'rct_time_start', { transaction });
+        await queryInterface.removeColumn('runs', 'rct_time_end', { transaction });
+    }),
+};


### PR DESCRIPTION
#### I have a JIRA ticket
- [X] branch and/or PR name(s) include(s) JIRA ID
- [X] issue has "Fix version" assigned
- [X] issue "Status" is set to "In review"
- [X] PR labels are selected

Notable changes for users:
- N/A

Notable changes for developers:
- N/A

Changes made to the database:
- Added two more virtual columns to runs, rct_time_start and rct_time_end that coalesce first/last TF timestamps with run start/stop
