### PR TITLE
[OGUI-1610] Bump NodeJS to v22 for GH Actions

### DIFF
--- a/.github/workflows/bookkeeping.yml
+++ b/.github/workflows/bookkeeping.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '22.x'
       - name: Installing dependencies
         run: npm ci
       - name: Running linter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '18.x'
+        node-version: '22.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Check released tag matches ALICE O2 naming pattern
       run: |
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '18.x'
+        node-version: '22.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Install production dependencies
       run: npm install --only=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #
 # ---- Base ----
-FROM node:22-alpine as base
+FROM node:22-alpine3.21 as base
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -18,11 +18,11 @@ FROM base AS developmentdependencies
 # Installs Git and packages required for Puppeteer
 # https://pkgs.alpinelinux.org/packages
 RUN apk add --no-cache \
-    chromium \
-    freetype \
-    freetype-dev \
-    harfbuzz \
-    ca-certificates
+    chromium=132.0.6834.83-r0 \
+    freetype=2.13.3-r0 \
+    freetype-dev=2.13.3-r0 \
+    harfbuzz=9.0.0-r1 \
+    ca-certificates=20241121-r1
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #
 # ---- Base ----
-FROM node:22-alpine3.21 as base
+FROM node:22-alpine3.20 as base
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -9,7 +9,7 @@ WORKDIR /usr/src/app
 EXPOSE 4000
 
 RUN apk add --no-cache \
-    bash=5.2.37-r0
+    bash=5.2.26-r0
 
 #
 # ---- Development Dependencies ----
@@ -18,10 +18,10 @@ FROM base AS developmentdependencies
 # Installs Git and packages required for Puppeteer
 # https://pkgs.alpinelinux.org/packages
 RUN apk add --no-cache \
-    chromium=132.0.6834.83-r0 \
-    freetype=2.13.3-r0 \
-    freetype-dev=2.13.3-r0 \
-    harfbuzz=9.0.0-r1 \
+    chromium=131.0.6778.108-r0 \
+    freetype=2.13.2-r0 \
+    freetype-dev=2.13.2-r0 \
+    harfbuzz=8.5.0-r0 \
     ca-certificates=20241121-r1
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #
 # ---- Base ----
-FROM node:18-alpine3.18 as base
+FROM node:22-alpine as base
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -9,7 +9,7 @@ WORKDIR /usr/src/app
 EXPOSE 4000
 
 RUN apk add --no-cache \
-    bash=5.2.15-r5
+    bash
 
 #
 # ---- Development Dependencies ----
@@ -18,11 +18,11 @@ FROM base AS developmentdependencies
 # Installs Git and packages required for Puppeteer
 # https://pkgs.alpinelinux.org/packages
 RUN apk add --no-cache \
-    chromium=119.0.6045.159-r0 \
-    freetype=2.13.0-r5 \
-    freetype-dev=2.13.0-r5 \
-    harfbuzz=7.3.0-r0 \
-    ca-certificates=20241121-r1
+    chromium \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /usr/src/app
 EXPOSE 4000
 
 RUN apk add --no-cache \
-    bash
+    bash=5.2.37-r0
 
 #
 # ---- Development Dependencies ----

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,6 +1,8 @@
 # Development
 
 ## Getting started
+### Requirements
+NodeJS - `v22` (min)
 ### Configuration
 The following `.env` configuration is the bare minimum required for development. It must be placed in the top dir. 
 ```ini

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "supertest": "7.0.0"
       },
       "engines": {
-        "node": ">= 18.x"
+        "node": ">= 22.x"
       }
     },
     "node_modules/@aliceo2/web-ui": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "docker-update": "node scripts/update-dockerfile.js"
   },
   "engines": {
-    "node": ">= 18.x"
+    "node": ">= 22.x"
   },
   "dependencies": {
     "@aliceo2/web-ui": "2.7.0",

--- a/test/public/defaults.js
+++ b/test/public/defaults.js
@@ -56,7 +56,7 @@ const getUrl = () => `http://localhost:${server.address().port}`;
  * @returns {Promise<Array>} Array of multiple objects, consisting of Page, Browser and Url.
  */
 module.exports.defaultBefore = async () => {
-    const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox'] });
+    const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-gpu', '--disable-setuid-sandbox'] });
     const page = await browser.newPage();
     page.setDefaultTimeout(1500);
     page.setDefaultNavigationTimeout(5000);

--- a/test/public/defaults.js
+++ b/test/public/defaults.js
@@ -56,7 +56,7 @@ const getUrl = () => `http://localhost:${server.address().port}`;
  * @returns {Promise<Array>} Array of multiple objects, consisting of Page, Browser and Url.
  */
 module.exports.defaultBefore = async () => {
-    const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
+    const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox'] });
     const page = await browser.newPage();
     page.setDefaultTimeout(1500);
     page.setDefaultNavigationTimeout(5000);


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- NA

Notable changes for developers:
- Updates min supported NodeJS to 22 to cover next year of Beam Operations
- disables usage of GPU on puppetter as it hangs on docker-alpine (known issue on their repository)
- Updates alpine version as otherwise node 22 was not available
- Updates dependencies for puppeteer as needed due to alpine update
- moves to using `headles: true` instead of `headless: 'new'` with the new puppeteer version


Changes made to the database:
-
