### PR TITLE
[O2B-1430] Rename trigger counters to CTP trigger counters

### DIFF
--- a/cxx-client/CMakeLists.txt
+++ b/cxx-client/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(BookkeepingProtos OBJECT
         ${PROTO_DIR}/run.proto
         ${PROTO_DIR}/dplProcessExecution.proto
         ${PROTO_DIR}/qcFlag.proto
-        ${PROTO_DIR}/triggerCounters.proto
+        ${PROTO_DIR}/ctpTriggerCounters.proto
 )
 
 target_link_libraries(BookkeepingProtos
@@ -64,9 +64,9 @@ add_library(BookkeepingApi SHARED
         include/BookkeepingApi/QcFlag.h
         src/grpc/services/GrpcQcFlagServiceClient.cxx
         src/grpc/services/GrpcQcFlagServiceClient.h
-        include/BookkeepingApi/TriggerCountersServiceClient.h
-        src/grpc/services/GrpcTriggerCountersServiceClient.h
-        src/grpc/services/GrpcTriggerCountersServiceClient.cxx
+        include/BookkeepingApi/CtpTriggerCountersServiceClient.h
+        src/grpc/services/GrpcCtpTriggerCountersServiceClient.h
+        src/grpc/services/GrpcCtpTriggerCountersServiceClient.cxx
         include/BookkeepingApi/RunServiceClient.h
         src/grpc/services/GrpcRunServiceClient.h
         src/grpc/services/GrpcRunServiceClient.cxx
@@ -115,7 +115,7 @@ install(FILES
         ${PROTO_OUT_DIR}/run.pb.h
         ${PROTO_OUT_DIR}/dplProcessExecution.pb.h
         ${PROTO_OUT_DIR}/qcFlag.pb.h
-        ${PROTO_OUT_DIR}/triggerCounters.pb.h
+        ${PROTO_OUT_DIR}/ctpTriggerCounters.pb.h
         DESTINATION "include"
 )
 

--- a/cxx-client/example/exampleSpecificServices.cxx
+++ b/cxx-client/example/exampleSpecificServices.cxx
@@ -61,9 +61,9 @@ int main(int argc, char** argv)
     std::cout << simulationPassQcFlagIds[simulationPassQcFlagIds.size() - 1] << std::endl;
 
     // Test trigger counters registration
-    client->triggerCounters()->createOrUpdateForRun(108, "CLASS-NAME", 123, 1, 2, 3, 4, 5, 6);
+    client->ctpTriggerCounters()->createOrUpdateForRun(108, "CLASS-NAME", 123, 1, 2, 3, 4, 5, 6);
     std::cout << "Successfully created trigger counters" << std::endl;
-    client->triggerCounters()->createOrUpdateForRun(108, "CLASS-NAME", 1234, 10, 20, 30, 40, 50, 60);
+    client->ctpTriggerCounters()->createOrUpdateForRun(108, "CLASS-NAME", 1234, 10, 20, 30, 40, 50, 60);
     std::cout << "Successfully updated trigger counters" << std::endl;
 
     // Test run update

--- a/cxx-client/include/BookkeepingApi/BkpClient.h
+++ b/cxx-client/include/BookkeepingApi/BkpClient.h
@@ -39,6 +39,9 @@ class BkpClient
   /// Returns the client for trigger counters
   virtual const std::unique_ptr<CtpTriggerCountersServiceClient>& ctpTriggerCounters() const = 0;
 
+  /// @deprecated use `ctpTriggerCounters` instead
+  virtual const std::unique_ptr<CtpTriggerCountersServiceClient>& triggerCounters() const = 0;
+
   /// Returns the client for runs
   virtual const std::unique_ptr<RunServiceClient>& run() const = 0;
 };

--- a/cxx-client/include/BookkeepingApi/BkpClient.h
+++ b/cxx-client/include/BookkeepingApi/BkpClient.h
@@ -16,7 +16,7 @@
 #include "FlpServiceClient.h"
 #include "DplProcessExecutionClient.h"
 #include "QcFlagServiceClient.h"
-#include "TriggerCountersServiceClient.h"
+#include "CtpTriggerCountersServiceClient.h"
 #include "RunServiceClient.h"
 
 namespace o2::bkp::api
@@ -37,7 +37,7 @@ class BkpClient
   virtual const std::unique_ptr<QcFlagServiceClient>& qcFlag() const = 0;
 
   /// Returns the client for trigger counters
-  virtual const std::unique_ptr<TriggerCountersServiceClient>& triggerCounters() const = 0;
+  virtual const std::unique_ptr<CtpTriggerCountersServiceClient>& ctpTriggerCounters() const = 0;
 
   /// Returns the client for runs
   virtual const std::unique_ptr<RunServiceClient>& run() const = 0;

--- a/cxx-client/include/BookkeepingApi/CtpTriggerCountersServiceClient.h
+++ b/cxx-client/include/BookkeepingApi/CtpTriggerCountersServiceClient.h
@@ -12,18 +12,18 @@
 // Created by mboulais on 27/05/24.
 //
 
-#ifndef CXX_CLIENT_BOOKKEEPINGAPI_TRIGGERCOUNTERSSERVICECLIENT_H
-#define CXX_CLIENT_BOOKKEEPINGAPI_TRIGGERCOUNTERSSERVICECLIENT_H
+#ifndef CXX_CLIENT_BOOKKEEPINGAPI_CTPTRIGGERCOUNTERSSERVICECLIENT_H
+#define CXX_CLIENT_BOOKKEEPINGAPI_CTPTRIGGERCOUNTERSSERVICECLIENT_H
 
 #include <string>
 #include <cstdint>
 
 namespace o2::bkp::api
 {
-class TriggerCountersServiceClient
+class CtpTriggerCountersServiceClient
 {
  public:
-  virtual ~TriggerCountersServiceClient() = default;
+  virtual ~CtpTriggerCountersServiceClient() = default;
 
   /// Create or update the trigger counters for a given run and class name
   virtual void createOrUpdateForRun(
@@ -39,4 +39,4 @@ class TriggerCountersServiceClient
 };
 } // namespace o2::bkp::api
 
-#endif // CXX_CLIENT_BOOKKEEPINGAPI_TRIGGERCOUNTERSSERVICECLIENT_H
+#endif // CXX_CLIENT_BOOKKEEPINGAPI_CTPTRIGGERCOUNTERSSERVICECLIENT_H

--- a/cxx-client/src/grpc/GrpcBkpClient.cxx
+++ b/cxx-client/src/grpc/GrpcBkpClient.cxx
@@ -67,6 +67,11 @@ const unique_ptr<CtpTriggerCountersServiceClient>& GrpcBkpClient::ctpTriggerCoun
   return mCtpTriggerCountersClient;
 }
 
+const unique_ptr<CtpTriggerCountersServiceClient>& GrpcBkpClient::triggerCounters() const
+{
+  return mCtpTriggerCountersClient;
+}
+
 const unique_ptr<RunServiceClient>& GrpcBkpClient::run() const {
   return mRunClient;
 }

--- a/cxx-client/src/grpc/GrpcBkpClient.cxx
+++ b/cxx-client/src/grpc/GrpcBkpClient.cxx
@@ -15,7 +15,7 @@
 #include "grpc/services/GrpcFlpServiceClient.h"
 #include "grpc/services/GrpcDplProcessExecutionClient.h"
 #include "grpc/services/GrpcQcFlagServiceClient.h"
-#include "grpc/services/GrpcTriggerCountersServiceClient.h"
+#include "grpc/services/GrpcCtpTriggerCountersServiceClient.h"
 #include "grpc/services/GrpcRunServiceClient.h"
 
 using grpc::Channel;
@@ -34,7 +34,7 @@ namespace o2::bkp::api::grpc
 using services::GrpcDplProcessExecutionClient;
 using services::GrpcFlpServiceClient;
 using services::GrpcQcFlagServiceClient;
-using services::GrpcTriggerCountersServiceClient;
+using services::GrpcCtpTriggerCountersServiceClient;
 using services::GrpcRunServiceClient;
 
 GrpcBkpClient::GrpcBkpClient(const string& uri)
@@ -43,7 +43,7 @@ GrpcBkpClient::GrpcBkpClient(const string& uri)
   mFlpClient = make_unique<GrpcFlpServiceClient>(channel);
   mDplProcessExecutionClient = make_unique<GrpcDplProcessExecutionClient>(channel);
   mQcFlagClient = make_unique<GrpcQcFlagServiceClient>(channel);
-  mTriggerCountersClient = make_unique<GrpcTriggerCountersServiceClient>(channel);
+  mCtpTriggerCountersClient = make_unique<GrpcCtpTriggerCountersServiceClient>(channel);
   mRunClient = make_unique<GrpcRunServiceClient>(channel);
 }
 
@@ -62,9 +62,9 @@ const unique_ptr<QcFlagServiceClient>& GrpcBkpClient::qcFlag() const
   return mQcFlagClient;
 }
 
-const unique_ptr<TriggerCountersServiceClient>& GrpcBkpClient::triggerCounters() const
+const unique_ptr<CtpTriggerCountersServiceClient>& GrpcBkpClient::ctpTriggerCounters() const
 {
-  return mTriggerCountersClient;
+  return mCtpTriggerCountersClient;
 }
 
 const unique_ptr<RunServiceClient>& GrpcBkpClient::run() const {

--- a/cxx-client/src/grpc/GrpcBkpClient.h
+++ b/cxx-client/src/grpc/GrpcBkpClient.h
@@ -30,6 +30,9 @@ class GrpcBkpClient : public o2::bkp::api::BkpClient
 
   const std::unique_ptr<QcFlagServiceClient>& qcFlag() const override;
 
+  /// @deprecated use `ctpTriggerCounters` instead
+  const std::unique_ptr<CtpTriggerCountersServiceClient>& triggerCounters() const override;
+
   const std::unique_ptr<CtpTriggerCountersServiceClient>& ctpTriggerCounters() const override;
 
   const std::unique_ptr<RunServiceClient>& run() const override;

--- a/cxx-client/src/grpc/GrpcBkpClient.h
+++ b/cxx-client/src/grpc/GrpcBkpClient.h
@@ -30,7 +30,7 @@ class GrpcBkpClient : public o2::bkp::api::BkpClient
 
   const std::unique_ptr<QcFlagServiceClient>& qcFlag() const override;
 
-  const std::unique_ptr<TriggerCountersServiceClient>& triggerCounters() const override;
+  const std::unique_ptr<CtpTriggerCountersServiceClient>& ctpTriggerCounters() const override;
 
   const std::unique_ptr<RunServiceClient>& run() const override;
 
@@ -38,7 +38,7 @@ class GrpcBkpClient : public o2::bkp::api::BkpClient
   std::unique_ptr<::o2::bkp::api::FlpServiceClient> mFlpClient;
   std::unique_ptr<::o2::bkp::api::DplProcessExecutionClient> mDplProcessExecutionClient;
   std::unique_ptr<::o2::bkp::api::QcFlagServiceClient> mQcFlagClient;
-  std::unique_ptr<::o2::bkp::api::TriggerCountersServiceClient> mTriggerCountersClient;
+  std::unique_ptr<::o2::bkp::api::CtpTriggerCountersServiceClient> mCtpTriggerCountersClient;
   std::unique_ptr<::o2::bkp::api::RunServiceClient> mRunClient;
 };
 } // namespace o2::bkp::api::grpc

--- a/cxx-client/src/grpc/services/GrpcCtpTriggerCountersServiceClient.cxx
+++ b/cxx-client/src/grpc/services/GrpcCtpTriggerCountersServiceClient.cxx
@@ -12,22 +12,22 @@
 // Created by martin on 13/06/24.
 //
 
-#include "GrpcTriggerCountersServiceClient.h"
+#include "GrpcCtpTriggerCountersServiceClient.h"
 
 using grpc::ClientContext;
 using o2::bookkeeping::Empty;
-using o2::bookkeeping::TriggerCounterCreateOrUpdateRequest;
+using o2::bookkeeping::CtpTriggerCounterCreateOrUpdateRequest;
 
 namespace o2::bkp::api::grpc::services
 {
-GrpcTriggerCountersServiceClient::GrpcTriggerCountersServiceClient(const std::shared_ptr<::grpc::ChannelInterface>& channel)
+GrpcCtpTriggerCountersServiceClient::GrpcCtpTriggerCountersServiceClient(const std::shared_ptr<::grpc::ChannelInterface>& channel)
 {
-  mStub = o2::bookkeeping::TriggerCountersService::NewStub(channel);
+  mStub = o2::bookkeeping::CtpTriggerCountersService::NewStub(channel);
 }
-void GrpcTriggerCountersServiceClient::createOrUpdateForRun(uint32_t runNumber, const std::string& className, int64_t timestamp, uint64_t lmb, uint64_t lma, uint64_t l0b, uint64_t l0a, uint64_t l1b, uint64_t l1a)
+void GrpcCtpTriggerCountersServiceClient::createOrUpdateForRun(uint32_t runNumber, const std::string& className, int64_t timestamp, uint64_t lmb, uint64_t lma, uint64_t l0b, uint64_t l0a, uint64_t l1b, uint64_t l1a)
 {
   ClientContext context;
-  TriggerCounterCreateOrUpdateRequest request;
+  CtpTriggerCounterCreateOrUpdateRequest request;
   Empty response;
 
   request.set_runnumber(runNumber);

--- a/cxx-client/src/grpc/services/GrpcCtpTriggerCountersServiceClient.h
+++ b/cxx-client/src/grpc/services/GrpcCtpTriggerCountersServiceClient.h
@@ -12,27 +12,27 @@
 // Created by martin on 13/06/24.
 //
 
-#ifndef CXX_CLIENT_BOOKKEEPINGAPI_GRPCTRIGGERCOUNTERSSERVICECLIENT_H
-#define CXX_CLIENT_BOOKKEEPINGAPI_GRPCTRIGGERCOUNTERSSERVICECLIENT_H
+#ifndef CXX_CLIENT_BOOKKEEPINGAPI_GRPCCTPTRIGGERCOUNTERSSERVICECLIENT_H
+#define CXX_CLIENT_BOOKKEEPINGAPI_GRPCCTPTRIGGERCOUNTERSSERVICECLIENT_H
 
-#include "triggerCounters.grpc.pb.h"
-#include "BookkeepingApi/TriggerCountersServiceClient.h"
+#include "ctpTriggerCounters.grpc.pb.h"
+#include "BookkeepingApi/CtpTriggerCountersServiceClient.h"
 
 namespace o2::bkp::api::grpc::services
 {
 
-class GrpcTriggerCountersServiceClient: public TriggerCountersServiceClient
+class GrpcCtpTriggerCountersServiceClient: public CtpTriggerCountersServiceClient
 {
  public:
-  explicit GrpcTriggerCountersServiceClient(const std::shared_ptr<::grpc::ChannelInterface>& channel);
-  ~GrpcTriggerCountersServiceClient() override = default;
+  explicit GrpcCtpTriggerCountersServiceClient(const std::shared_ptr<::grpc::ChannelInterface>& channel);
+  ~GrpcCtpTriggerCountersServiceClient() override = default;
 
   void createOrUpdateForRun(uint32_t runNumber, const std::string& className, int64_t timestamp, uint64_t lmb, uint64_t lma, uint64_t l0b, uint64_t l0a, uint64_t l1b, uint64_t l1a) override;
 
  private:
-  std::unique_ptr<o2::bookkeeping::TriggerCountersService::Stub> mStub;
+  std::unique_ptr<o2::bookkeeping::CtpTriggerCountersService::Stub> mStub;
 };
 
 } // namespace o2::bkp::api::grpc::services
 
-#endif // CXX_CLIENT_BOOKKEEPINGAPI_GRPCTRIGGERCOUNTERSSERVICECLIENT_H
+#endif // CXX_CLIENT_BOOKKEEPINGAPI_GRPCCTPTRIGGERCOUNTERSSERVICECLIENT_H

--- a/lib/database/adapters/CtpTriggerCountersAdapter.js
+++ b/lib/database/adapters/CtpTriggerCountersAdapter.js
@@ -12,9 +12,9 @@
  */
 
 /**
- * TriggerCountersAdapter
+ * CtpTriggerCountersAdapter
  */
-class TriggerCountersAdapter {
+class CtpTriggerCountersAdapter {
     /**
      * Constructor
      */
@@ -26,8 +26,8 @@ class TriggerCountersAdapter {
     /**
      * Converts the given database object to an entity object.
      *
-     * @param {SequelizeTriggerCounters} databaseObject Object to convert.
-     * @returns {TriggerCounters} Converted entity object.
+     * @param {SequelizeCtpTriggerCounters} databaseObject Object to convert.
+     * @returns {CtpTriggerCounters} Converted entity object.
      */
     toEntity({ id, timestamp, runNumber, className, lmb, lma, l0b, l0a, l1b, l1a, createdAt, updatedAt }) {
         return {
@@ -49,8 +49,8 @@ class TriggerCountersAdapter {
     /**
      * Converts the given entity object to a database object.
      *
-     * @param {TriggerCounters} entityObject Entity to convert
-     * @returns {Partial<SequelizeTriggerCounters>} Sequelize object
+     * @param {CtpTriggerCounters} entityObject Entity to convert
+     * @returns {Partial<SequelizeCtpTriggerCounters>} Sequelize object
      */
     toDatabase({ id, timestamp, runNumber, className, lmb, lma, l0b, l0a, l1b, l1a }) {
         return {
@@ -68,4 +68,4 @@ class TriggerCountersAdapter {
     }
 }
 
-exports.TriggerCountersAdapter = TriggerCountersAdapter;
+exports.CtpTriggerCountersAdapter = CtpTriggerCountersAdapter;

--- a/lib/database/adapters/index.js
+++ b/lib/database/adapters/index.js
@@ -45,7 +45,7 @@ const RunTypeAdapter = require('./RunTypeAdapter');
 const SimulationPassAdapter = require('./SimulationPassAdapter.js');
 const { SimulationPassQcFlagAdapter } = require('./SimulationPassQcFlagAdapter');
 const TagAdapter = require('./TagAdapter');
-const { TriggerCountersAdapter } = require('./TriggerCountersAdapter');
+const { CtpTriggerCountersAdapter } = require('./CtpTriggerCountersAdapter');
 const UserAdapter = require('./UserAdapter');
 
 const attachmentAdapter = new AttachmentAdapter();
@@ -82,7 +82,7 @@ const runTypeAdapter = new RunTypeAdapter();
 const simulationPassAdapter = new SimulationPassAdapter();
 const simulationPassQcFlagAdapter = new SimulationPassQcFlagAdapter();
 const tagAdapter = new TagAdapter();
-const triggerCountersAdapter = new TriggerCountersAdapter();
+const ctpTriggerCountersAdapter = new CtpTriggerCountersAdapter();
 const userAdapter = new UserAdapter();
 
 // Fill dependencies
@@ -177,6 +177,6 @@ module.exports = {
     simulationPassAdapter,
     simulationPassQcFlagAdapter,
     tagAdapter,
-    triggerCountersAdapter,
+    ctpTriggerCountersAdapter,
     userAdapter,
 };

--- a/lib/database/migrations/20250211085415-rename-trigger-counters-to-ctp-trigger-counters.js
+++ b/lib/database/migrations/20250211085415-rename-trigger-counters-to-ctp-trigger-counters.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    up: async (queryInterface) => await queryInterface.sequelize.query('RENAME TABLE trigger_counters TO ctp_trigger_counters'),
+
+    down: async (queryInterface) => queryInterface.sequelize.query('RENAME TABLE ctp_trigger_counters TO trigger_counters'),
+};

--- a/lib/database/models/ctpTriggerCounters.js
+++ b/lib/database/models/ctpTriggerCounters.js
@@ -1,7 +1,7 @@
 const Sequelize = require('sequelize');
 
 module.exports = (sequelize) => {
-    const TriggerCounters = sequelize.define('TriggerCounters', {
+    const CtpTriggerCounters = sequelize.define('CtpTriggerCounters', {
         id: {
             allowNull: false,
             primaryKey: true,
@@ -54,9 +54,9 @@ module.exports = (sequelize) => {
         },
     }, { indexes: [{ unique: true, fields: ['runNumber', 'className'] }] });
 
-    TriggerCounters.associate = (models) => {
-        TriggerCounters.belongsTo(models.Run, { as: 'run', targetKey: 'runNumber', foreignKey: 'runNumber' });
+    CtpTriggerCounters.associate = (models) => {
+        CtpTriggerCounters.belongsTo(models.Run, { as: 'run', targetKey: 'runNumber', foreignKey: 'runNumber' });
     };
 
-    return TriggerCounters;
+    return CtpTriggerCounters;
 };

--- a/lib/database/models/index.js
+++ b/lib/database/models/index.js
@@ -45,7 +45,7 @@ const SimulationPass = require('./simulationPass.js');
 const SimulationPassQcFlag = require('./simulationPassQcFlag.js');
 const StableBeamRun = require('./stableBeamsRun.js');
 const Tag = require('./tag');
-const TriggerCounters = require('./triggerCounters');
+const CtpTriggerCounters = require('./ctpTriggerCounters');
 const User = require('./user');
 
 module.exports = (sequelize) => {
@@ -84,7 +84,7 @@ module.exports = (sequelize) => {
         SimulationPassQcFlag: SimulationPassQcFlag(sequelize),
         StableBeamRun: StableBeamRun(sequelize),
         Tag: Tag(sequelize),
-        TriggerCounters: TriggerCounters(sequelize),
+        CtpTriggerCounters: CtpTriggerCounters(sequelize),
         User: User(sequelize),
     };
 

--- a/lib/database/models/typedefs/SequelizeCtpTriggerCounters.js
+++ b/lib/database/models/typedefs/SequelizeCtpTriggerCounters.js
@@ -12,7 +12,7 @@
  */
 
 /**
- * @typedef SequelizeTriggerCounters
+ * @typedef SequelizeCtpTriggerCounters
  *
  * @property {number} id
  * @property {string} timestamp

--- a/lib/database/repositories/CtpTriggerCountersRepository.js
+++ b/lib/database/repositories/CtpTriggerCountersRepository.js
@@ -11,19 +11,19 @@
  *  or submit itself to any jurisdiction.
  */
 
-const { models: { TriggerCounters } } = require('../index.js');
+const { models: { CtpTriggerCounters } } = require('../index.js');
 const Repository = require('./Repository.js');
 
 /**
- * Sequelize implementation of the TriggerCountersRepository.
+ * Sequelize implementation of the CtpTriggerCountersRepository.
  */
-class TriggerCountersRepository extends Repository {
+class CtpTriggerCountersRepository extends Repository {
     /**
      * Constructor
      */
     constructor() {
-        super(TriggerCounters);
+        super(CtpTriggerCounters);
     }
 }
 
-module.exports = new TriggerCountersRepository();
+module.exports = new CtpTriggerCountersRepository();

--- a/lib/database/repositories/index.js
+++ b/lib/database/repositories/index.js
@@ -50,7 +50,7 @@ const SimulationPassRepository = require('./SimulationPassRepository.js');
 const SimulationPassQcFlagRepository = require('./SimulationPassQcFlagRepository.js');
 const StableBeamRunsRepository = require('./StableBeamRunsRepository.js');
 const TagRepository = require('./TagRepository');
-const TriggerCountersRepository = require('./TriggerCountersRepository');
+const CtpTriggerCountersRepository = require('./CtpTriggerCountersRepository');
 const UserRepository = require('./UserRepository');
 
 module.exports = {
@@ -93,6 +93,6 @@ module.exports = {
     SimulationPassQcFlagRepository,
     StableBeamRunsRepository,
     TagRepository,
-    TriggerCountersRepository,
+    CtpTriggerCountersRepository,
     UserRepository,
 };

--- a/lib/database/seeders/20240603124221-add-trigger-counters.js
+++ b/lib/database/seeders/20240603124221-add-trigger-counters.js
@@ -3,7 +3,7 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
     up: async (queryInterface) => queryInterface.sequelize.transaction((transaction) => Promise.all([
-        queryInterface.bulkInsert('trigger_counters', [
+        queryInterface.bulkInsert('ctp_trigger_counters', [
             {
                 id: 1,
                 timestamp: '2024-06-03 14:45:12',
@@ -36,5 +36,5 @@ module.exports = {
     ])),
 
     down: async (queryInterface) => queryInterface.sequelize.transaction((transaction) =>
-        queryInterface.bulkDelete('trigger_counters', null, { transaction })),
+        queryInterface.bulkDelete('ctp_trigger_counters', null, { transaction })),
 };

--- a/lib/domain/entities/CtpTriggerCounters.js
+++ b/lib/domain/entities/CtpTriggerCounters.js
@@ -12,7 +12,7 @@
  */
 
 /**
- * @typedef TriggerCounters
+ * @typedef CtpTriggerCounters
  *
  * @property {number} id
  * @property {number} timestamp

--- a/lib/public/views/Runs/Details/RunDetailsModel.js
+++ b/lib/public/views/Runs/Details/RunDetailsModel.js
@@ -25,7 +25,7 @@ export const RUN_DETAILS_PANELS_KEYS = {
     LOGS: 'logs',
     FLPS: 'flps',
     DPL_PROCESSES: 'dpl-processes',
-    TRIGGER_COUNTERS: 'trigger-counters',
+    CTP_TRIGGER_COUNTERS: 'ctp-trigger-counters',
     CTP_TRIGGER_CONFIGURATION: 'trigger-configuration',
 };
 
@@ -334,8 +334,8 @@ class RunDetailsTabbedPanelModel extends TabbedPanelModel {
             case RUN_DETAILS_PANELS_KEYS.DPL_PROCESSES:
                 this._fetchDplTasksPanelData();
                 break;
-            case RUN_DETAILS_PANELS_KEYS.TRIGGER_COUNTERS:
-                this._fetchTriggerCountersPanelData();
+            case RUN_DETAILS_PANELS_KEYS.CTP_TRIGGER_COUNTERS:
+                this._fetchCtpTriggerCountersPanelData();
                 break;
         }
     }
@@ -416,14 +416,14 @@ class RunDetailsTabbedPanelModel extends TabbedPanelModel {
      * @return {void} resolves once data has been fetched or request failed
      * @private
      */
-    async _fetchTriggerCountersPanelData() {
+    async _fetchCtpTriggerCountersPanelData() {
         this.currentPanelData = RemoteData.loading();
         this.notify();
 
         if (this._runNumber !== null) {
             try {
-                const { data: triggerCountersOfRun } = await getRemoteData(`/api/trigger-counters/${this._runNumber}`);
-                this.currentPanelData = RemoteData.success(triggerCountersOfRun);
+                const { data: ctpTriggerCountersOfRun } = await getRemoteData(`/api/ctp-trigger-counters/${this._runNumber}`);
+                this.currentPanelData = RemoteData.success(ctpTriggerCountersOfRun);
             } catch (error) {
                 this.currentPanelData = RemoteData.failure(error);
             }

--- a/lib/public/views/Runs/Details/runDetailsComponent.js
+++ b/lib/public/views/Runs/Details/runDetailsComponent.js
@@ -515,7 +515,7 @@ export const runDetailsComponent = (runDetailsModel, router) => runDetailsModel.
                     [RUN_DETAILS_PANELS_KEYS.LOGS]: 'Log entries',
                     [RUN_DETAILS_PANELS_KEYS.FLPS]: 'FLP statistics',
                     [RUN_DETAILS_PANELS_KEYS.DPL_PROCESSES]: 'QC/PDP tasks',
-                    [RUN_DETAILS_PANELS_KEYS.TRIGGER_COUNTERS]: 'Trigger counters',
+                    [RUN_DETAILS_PANELS_KEYS.CTP_TRIGGER_COUNTERS]: 'Trigger counters',
                     [RUN_DETAILS_PANELS_KEYS.CTP_TRIGGER_CONFIGURATION]: 'CTP Trigger Config',
                 },
                 {
@@ -559,8 +559,8 @@ export const runDetailsComponent = (runDetailsModel, router) => runDetailsModel.
                         },
                         Failure: (errors) => errors.map(errorAlert),
                     }),
-                    [RUN_DETAILS_PANELS_KEYS.TRIGGER_COUNTERS]: (triggerCounters) => table(
-                        triggerCounters,
+                    [RUN_DETAILS_PANELS_KEYS.CTP_TRIGGER_COUNTERS]: (ctpTriggerCounters) => table(
+                        ctpTriggerCounters,
                         {
                             className: {
                                 visible: true,

--- a/lib/server/controllers/ctpTriggerCounters.controller.js
+++ b/lib/server/controllers/ctpTriggerCounters.controller.js
@@ -2,20 +2,20 @@ const { dtoValidator } = require('../utilities');
 const { DtoFactory } = require('../../domain/dtos/DtoFactory');
 const Joi = require('joi');
 const { updateExpressResponseFromNativeError } = require('../express/updateExpressResponseFromNativeError');
-const { triggerCountersService } = require('../services/triggerCounters/TriggerCountersService');
+const { ctpTriggerCountersService } = require('../services/ctpTriggerCounters/CtpTriggerCountersService');
 
 // eslint-disable-next-line valid-jsdoc
 /**
  * Return all the trigger counters for a given run
  */
-const getAllTriggerCountersForRunHandler = async (request, response) => {
+const getAllCtpTriggerCountersForRunHandler = async (request, response) => {
     const requestDto = await dtoValidator(DtoFactory.paramsOnly({
         runNumber: Joi.number().required(),
     }), request, response);
 
     if (requestDto) {
         try {
-            const data = await triggerCountersService.getPerRun(requestDto.params.runNumber);
+            const data = await ctpTriggerCountersService.getPerRun(requestDto.params.runNumber);
             response.status(200).json({ data });
         } catch (error) {
             updateExpressResponseFromNativeError(response, error);
@@ -24,5 +24,5 @@ const getAllTriggerCountersForRunHandler = async (request, response) => {
 };
 
 module.exports = {
-    getAllTriggerCountersForRunHandler,
+    getAllCtpTriggerCountersForRunHandler,
 };

--- a/lib/server/controllers/gRPC/GRPCCtpTriggerCountersController.js
+++ b/lib/server/controllers/gRPC/GRPCCtpTriggerCountersController.js
@@ -11,22 +11,22 @@
  *  or submit itself to any jurisdiction.
  */
 
-const { triggerCountersService } = require('../../services/triggerCounters/TriggerCountersService.js');
+const { ctpTriggerCountersService } = require('../../services/ctpTriggerCounters/CtpTriggerCountersService.js');
 
 /**
- * Controller to handle requests through gRPC TriggerCounters
+ * Controller to handle requests through gRPC CtpTriggerCounters
  */
-class GRPCTriggerCountersController {
+class GRPCCtpTriggerCountersController {
     /**
      * Constructor
      */
     constructor() {
-        this.triggerCountersService = triggerCountersService;
+        this.ctpTriggerCountersService = ctpTriggerCountersService;
     }
 
     // eslint-disable-next-line require-jsdoc
     async CreateOrUpdateForRun({ runNumber, className, timestamp, lmb, lma, l0b, l0a, l1b, l1a }) {
-        await this.triggerCountersService.createOrUpdatePerRun(
+        await this.ctpTriggerCountersService.createOrUpdatePerRun(
             { runNumber, className },
             { timestamp: timestamp !== undefined ? Number(timestamp) : timestamp, lmb, lma, l0b, l0a, l1b, l1a },
         );
@@ -35,4 +35,4 @@ class GRPCTriggerCountersController {
     }
 }
 
-exports.GRPCTriggerCountersController = GRPCTriggerCountersController;
+exports.GRPCCtpTriggerCountersController = GRPCCtpTriggerCountersController;

--- a/lib/server/controllers/index.js
+++ b/lib/server/controllers/index.js
@@ -22,7 +22,7 @@ const RunTypesController = require('./runTypes.controller');
 const RunsController = require('./runs.controller');
 const StatusController = require('./status.controller');
 const TagsController = require('./tags.controller');
-const TriggerCountersController = require('./triggerCounters.controller');
+const CtpTriggerCountersController = require('./ctpTriggerCounters.controller');
 
 module.exports = {
     AttachmentsController,
@@ -36,5 +36,5 @@ module.exports = {
     RunsController,
     StatusController,
     TagsController,
-    TriggerCountersController,
+    CtpTriggerCountersController,
 };

--- a/lib/server/gRPC/servicesImplementationsMappings.js
+++ b/lib/server/gRPC/servicesImplementationsMappings.js
@@ -18,7 +18,7 @@ const { GRPCEnvironmentController } = require('../controllers/gRPC/GRPCEnvironme
 const { GRPCLhcFillController } = require('../controllers/gRPC/GRPCLhcFIllController.js');
 const { GRPCDplProcessExecutionController } = require('../controllers/gRPC/GRPCDplProcessExecutionController.js');
 const { GRPCQcFlagController } = require('../controllers/gRPC/GRPCQcFlagController.js');
-const { GRPCTriggerCountersController } = require('../controllers/gRPC/GRPCTriggerCountersController.js');
+const { GRPCCtpTriggerCountersController } = require('../controllers/gRPC/GRPCCtpTriggerCountersController.js');
 
 /**
  * Object containing for each proto name (properties' name) a list of object containing the service definition and its corresponding service
@@ -67,10 +67,10 @@ exports.servicesImplementationsMappings = {
             implementation: new GRPCQcFlagController(),
         },
     ],
-    triggerCounters: [
+    ctpTriggerCounters: [
         {
-            service: (proto) => proto.TriggerCountersService,
-            implementation: new GRPCTriggerCountersController(),
+            service: (proto) => proto.CtpTriggerCountersService,
+            implementation: new GRPCCtpTriggerCountersController(),
         },
     ],
 };

--- a/lib/server/routers/ctpTriggerCounters.router.js
+++ b/lib/server/routers/ctpTriggerCounters.router.js
@@ -1,0 +1,7 @@
+const { getAllCtpTriggerCountersForRunHandler } = require('../controllers/ctpTriggerCounters.controller');
+
+exports.ctpTriggerCountersRouter = {
+    method: 'get',
+    path: '/ctp-trigger-counters/:runNumber',
+    controller: getAllCtpTriggerCountersForRunHandler,
+};

--- a/lib/server/routers/index.js
+++ b/lib/server/routers/index.js
@@ -36,7 +36,7 @@ const { qcFlagTypesRouter } = require('./qcFlagTypes.router.js');
 const { simulationPassesRouter } = require('./simulationPasses.router.js');
 const { dplDetectorsRouter } = require('./dplDetectors.router');
 const { qcFlagsRouter } = require('./qcFlag.router.js');
-const { triggerCountersRouter } = require('./triggerCounters.router.js');
+const { ctpTriggerCountersRouter } = require('./ctpTriggerCounters.router.js');
 
 const routes = [
     attachmentRoute,
@@ -62,7 +62,7 @@ const routes = [
     statisticsRouter,
     statusRoute,
     tagsRoute,
-    triggerCountersRouter,
+    ctpTriggerCountersRouter,
 ];
 
 /**

--- a/lib/server/routers/triggerCounters.router.js
+++ b/lib/server/routers/triggerCounters.router.js
@@ -1,7 +1,0 @@
-const { getAllTriggerCountersForRunHandler } = require('../controllers/triggerCounters.controller');
-
-exports.triggerCountersRouter = {
-    method: 'get',
-    path: '/trigger-counters/:runNumber',
-    controller: getAllTriggerCountersForRunHandler,
-};

--- a/lib/server/services/ctpTriggerCounters/CtpTriggerCountersService.js
+++ b/lib/server/services/ctpTriggerCounters/CtpTriggerCountersService.js
@@ -1,19 +1,19 @@
-const { TriggerCountersRepository } = require('../../../database/repositories');
-const { triggerCountersAdapter } = require('../../../database/adapters');
+const { CtpTriggerCountersRepository } = require('../../../database/repositories');
+const { ctpTriggerCountersAdapter } = require('../../../database/adapters');
 const { getRunOrFail } = require('../run/getRunOrFail.js');
 
 /**
  * Service related to trigger counters
  */
-class TriggerCountersService {
+class CtpTriggerCountersService {
     /**
      * Return the list of trigger counters linked to a given run
      *
      * @param {number} runNumber the run number of the run for which counters must be fetched
-     * @return {Promise<TriggerCounters[]>} the trigger counters for the run
+     * @return {Promise<CtpTriggerCounters[]>} the trigger counters for the run
      */
     async getPerRun(runNumber) {
-        return (await TriggerCountersRepository.findAll({ where: { runNumber } })).map(triggerCountersAdapter.toEntity);
+        return (await CtpTriggerCountersRepository.findAll({ where: { runNumber } })).map(ctpTriggerCountersAdapter.toEntity);
     }
 
     /**
@@ -22,13 +22,13 @@ class TriggerCountersService {
      * @param {object} criteria the criteria identifying the counters to update
      * @param {number} criteria.runNumber the run number of run for which trigger counters are created/updated
      * @param {string} criteria.className the run number of run for which trigger counters are created/updated
-     * @param {Pick<TriggerCounters, 'timestamp'|'lmb'|'lma'|'l0b'|'l0a'|'l1b'|'l1a'>} counters the actual counters data
+     * @param {Pick<CtpTriggerCounters, 'timestamp'|'lmb'|'lma'|'l0b'|'l0a'|'l1b'|'l1a'>} counters the actual counters data
      * @return {Promise<void>} resolves once the counters have been created
      */
     async createOrUpdatePerRun({ runNumber, className }, counters) {
         // Check that run exists
         const run = await getRunOrFail({ runNumber });
-        await TriggerCountersRepository.upsert({
+        await CtpTriggerCountersRepository.upsert({
             runNumber: run.runNumber,
             className,
             timestamp: counters.timestamp,
@@ -42,6 +42,6 @@ class TriggerCountersService {
     }
 }
 
-exports.TriggerCountersService = TriggerCountersService;
+exports.CtpTriggerCountersService = CtpTriggerCountersService;
 
-exports.triggerCountersService = new TriggerCountersService();
+exports.ctpTriggerCountersService = new CtpTriggerCountersService();

--- a/proto/ctpTriggerCounters.proto
+++ b/proto/ctpTriggerCounters.proto
@@ -4,11 +4,11 @@ package o2.bookkeeping;
 
 import 'common.proto';
 
-service TriggerCountersService {
-  rpc CreateOrUpdateForRun(TriggerCounterCreateOrUpdateRequest) returns (Empty);
+service CtpTriggerCountersService {
+  rpc CreateOrUpdateForRun(CtpTriggerCounterCreateOrUpdateRequest) returns (Empty);
 }
 
-message TriggerCounterCreateOrUpdateRequest {
+message CtpTriggerCounterCreateOrUpdateRequest {
   uint32 runNumber = 1;
   string className = 2;
   int64 timestamp = 3;

--- a/test/api/ctpTriggerCounters.test.js
+++ b/test/api/ctpTriggerCounters.test.js
@@ -6,10 +6,10 @@ const { expect } = require('chai');
 module.exports = () => {
     before(resetDatabaseContent);
 
-    describe('GET /api/trigger-counters', () => {
+    describe('GET /api/ctp-trigger-counters', () => {
         it('Should successfully return the list of trigger counters for a given run', async () => {
             {
-                const response = await request(server).get('/api/trigger-counters/1');
+                const response = await request(server).get('/api/ctp-trigger-counters/1');
 
                 expect(response.status).to.equal(200);
                 expect(response.body.data.map(({ id, runNumber, className }) => ({ id, runNumber, className }))).to.deep.eql([
@@ -18,7 +18,7 @@ module.exports = () => {
                 ]);
             }
             {
-                const response = await request(server).get('/api/trigger-counters/2');
+                const response = await request(server).get('/api/ctp-trigger-counters/2');
 
                 expect(response.status).to.equal(200);
                 expect(response.body.data.map(({ id }) => id)).to.eql([]);

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -33,7 +33,7 @@ const SimulationPassesSuite = require('./simulationPasses.test.js');
 const QcFlagTypesSuite = require('./qcFlagTypes.test.js');
 const DplDetectorsSuite = require('./dplDetectors.test.js');
 const QcFlagsSuite = require('./qcFlags.test.js');
-const TriggerCountersSuite = require('./triggerCounters.test');
+const CtpTriggerCountersSuite = require('./ctpTriggerCounters.test');
 const GaqDetectorsSuite = require('./gaqDetectors.test.js');
 
 module.exports = () => {
@@ -60,5 +60,5 @@ module.exports = () => {
     describe('DplDetectors API', DplDetectorsSuite);
     describe('QcFlagTypes API', QcFlagTypesSuite);
     describe('QcFlags API', QcFlagsSuite);
-    describe('TriggerCounters API', TriggerCountersSuite);
+    describe('CtpTriggerCounters API', CtpTriggerCountersSuite);
 };

--- a/test/lib/server/services/ctpTriggerCounters/CtpTriggerCountersService.test.js
+++ b/test/lib/server/services/ctpTriggerCounters/CtpTriggerCountersService.test.js
@@ -1,4 +1,4 @@
-const { triggerCountersService } = require('../../../../../lib/server/services/triggerCounters/TriggerCountersService');
+const { ctpTriggerCountersService } = require('../../../../../lib/server/services/ctpTriggerCounters/CtpTriggerCountersService');
 const { expect } = require('chai');
 const { resetDatabaseContent } = require('../../../../utilities/resetDatabaseContent.js');
 const assert = require('assert');
@@ -7,10 +7,10 @@ const { BadParameterError } = require('../../../../../lib/server/errors/BadParam
 /**
  * Simplify a trigger counter to extract properties interesting in testing (remove createdAt and updatedAt)
  *
- * @param {TriggerCounters} counters the counters to simplify
+ * @param {CtpTriggerCounters} counters the counters to simplify
  * @return {object} simplified trigger counters
  */
-const simplifyTriggerCounters = ({
+const simplifyCtpTriggerCounters = ({
     id,
     runNumber,
     className,
@@ -27,7 +27,7 @@ module.exports = () => {
     after(resetDatabaseContent);
 
     it('Should successfully return the list of trigger counters for a given run', async () => {
-        expect((await triggerCountersService.getPerRun(1)).map(simplifyTriggerCounters)).to.deep.eql([
+        expect((await ctpTriggerCountersService.getPerRun(1)).map(simplifyCtpTriggerCounters)).to.deep.eql([
             {
                 id: 1,
                 runNumber: 1,
@@ -53,7 +53,7 @@ module.exports = () => {
                 l1a: 2006,
             },
         ]);
-        expect(await triggerCountersService.getPerRun(2)).to.eql([]);
+        expect(await ctpTriggerCountersService.getPerRun(2)).to.eql([]);
     });
 
     it('Should successfully insert new counters for a given run', async () => {
@@ -67,14 +67,14 @@ module.exports = () => {
             l1b: 5,
             l1a: 6,
         };
-        await triggerCountersService.createOrUpdatePerRun(
+        await ctpTriggerCountersService.createOrUpdatePerRun(
             {
                 runNumber: 2,
                 className: 'CLASS-NAME',
             },
             counters,
         );
-        expect((await triggerCountersService.getPerRun(2)).map(simplifyTriggerCounters)).to.deep.eql([
+        expect((await ctpTriggerCountersService.getPerRun(2)).map(simplifyCtpTriggerCounters)).to.deep.eql([
             {
                 id: 3,
                 runNumber: 2,
@@ -95,14 +95,14 @@ module.exports = () => {
             l1b: 15,
             l1a: 16,
         };
-        await triggerCountersService.createOrUpdatePerRun(
+        await ctpTriggerCountersService.createOrUpdatePerRun(
             {
                 runNumber: 2,
                 className: 'CLASS-NAME',
             },
             counters,
         );
-        expect((await triggerCountersService.getPerRun(2)).map(simplifyTriggerCounters)).to.deep.eql([
+        expect((await ctpTriggerCountersService.getPerRun(2)).map(simplifyCtpTriggerCounters)).to.deep.eql([
             {
                 id: 3,
                 runNumber: 2,
@@ -114,7 +114,7 @@ module.exports = () => {
 
     it('Should throw when trying to create/update counters for a non-existing run', async () => {
         await assert.rejects(
-            () => triggerCountersService.createOrUpdatePerRun(
+            () => ctpTriggerCountersService.createOrUpdatePerRun(
                 { runNumber: 999, className: 'CLASS-NAME' },
                 { timestamp: 0, lmb: 0, lma: 0, l0b: 0, l0a: 0, l1b: 0, l1a: 0 },
             ),

--- a/test/lib/server/services/ctpTriggerCounters/index.js
+++ b/test/lib/server/services/ctpTriggerCounters/index.js
@@ -1,0 +1,8 @@
+const { resetDatabaseContent } = require('../../../../utilities/resetDatabaseContent');
+const CtpTriggerCountersServiceTest = require('./CtpTriggerCountersService.test');
+
+module.exports = () => {
+    before(resetDatabaseContent);
+
+    describe('CtpTriggerCountersService', CtpTriggerCountersServiceTest);
+};

--- a/test/lib/server/services/index.js
+++ b/test/lib/server/services/index.js
@@ -30,7 +30,7 @@ const DataPassesSuite = require('./dataPasses/index.js');
 const UserSuite = require('./user/index.js');
 const SimulationPassesSuite = require('./simulationPasses/index.js');
 const QcFlagsSuite = require('./qualityControlFlag/index.js');
-const TriggerCountersSuite = require('./triggerCounters/index.js');
+const CtpTriggerCountersSuite = require('./ctpTriggerCounters/index.js');
 const GaqDetectorSuite = require('./gaq');
 
 module.exports = () => {
@@ -56,5 +56,5 @@ module.exports = () => {
     describe('DataPasses', DataPassesSuite);
     describe('SimulationPasses', SimulationPassesSuite);
     describe('QC Flags', QcFlagsSuite);
-    describe('Trigger counters', TriggerCountersSuite);
+    describe('Trigger counters', CtpTriggerCountersSuite);
 };

--- a/test/lib/server/services/triggerCounters/index.js
+++ b/test/lib/server/services/triggerCounters/index.js
@@ -1,8 +1,0 @@
-const { resetDatabaseContent } = require('../../../../utilities/resetDatabaseContent');
-const TriggerCountersServiceTest = require('./TriggerCountersService.test');
-
-module.exports = () => {
-    before(resetDatabaseContent);
-
-    describe('TriggerCountersService', TriggerCountersServiceTest);
-};

--- a/test/public/runs/detail.test.js
+++ b/test/public/runs/detail.test.js
@@ -317,9 +317,9 @@ module.exports = () => {
     it('should successfully navigate to the trigger counters panel', async () => {
         await goToRunDetails(page, 1);
 
-        await pressElement(page, '#trigger-counters-tab');
+        await pressElement(page, '#ctp-trigger-counters-tab');
         await waitForTableLength(page, 2);
-        expectUrlParams(page, { page: 'run-detail', runNumber: 1, panel: 'trigger-counters' });
+        expectUrlParams(page, { page: 'run-detail', runNumber: 1, panel: 'ctp-trigger-counters' });
         expect(await getTableContent(page)).to.deep.eql([
             ['FIRST-CLASS-NAME', '101', '102', '103', '104', '105', '106'],
             ['SECOND-CLASS-NAME', '2,001', '2,002', '2,003', '2,004', '2,005', '2,006'],


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [X] explain what this PR does
- [ ] if it is a new feature, explain how you plan to use it
- [ ] tests are added
- [ ] documentation was updated or added

Notable changes for users:
- Trigger counters has been renamed to CTP trigger counters

Notable changes for developers:
- Trigger countres has been renamed to CTP trigger counters everywhere:
    - triggerCounters.proto has been renamed to ctpTriggerCounters.proto
    - c++ API has been updated accordingly

Changes made to the database:
- Renamed trigger\_counters to ctp\_trigger\_counters
