### PR TITLE
Change type of reconstructed_events_count in data_passes_versions table to hold bigger numbers

### DIFF
--- a/lib/database/migrations/v1/20250611180000-change-reconstructed-events-column-type.js
+++ b/lib/database/migrations/v1/20250611180000-change-reconstructed-events-column-type.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const MODIFY_COLUMN_TYPE = `
+    ALTER TABLE data_pass_versions MODIFY reconstructed_events_count BIGINT UNSIGNED;
+`;
+
+const RESTORE_COLUMN_TYPE = `
+    ALTER TABLE data_pass_versions MODIFY reconstructed_events_count INTEGER;
+`;
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    up: async (queryInterface) => queryInterface.sequelize.transaction(async (transaction) => {
+        await queryInterface.sequelize.query(MODIFY_COLUMN_TYPE, { transaction });
+    }),
+
+    down: async (queryInterface) => queryInterface.sequelize.transaction(async (transaction) => {
+        await queryInterface.sequelize.query(RESTORE_COLUMN_TYPE, { transaction });
+    }),
+};

--- a/lib/database/migrations/v1/20250611180000-change-reconstructed-events-column-type.js
+++ b/lib/database/migrations/v1/20250611180000-change-reconstructed-events-column-type.js
@@ -4,7 +4,7 @@ const MODIFY_COLUMN_TYPE = `
     ALTER TABLE data_pass_versions MODIFY reconstructed_events_count BIGINT UNSIGNED;
 `;
 
-const RESTORE_COLUMN_TYPE = `
+const ROLLBACK_COLUMN_TYPE = `
     ALTER TABLE data_pass_versions MODIFY reconstructed_events_count INTEGER;
 `;
 
@@ -15,6 +15,6 @@ module.exports = {
     }),
 
     down: async (queryInterface) => queryInterface.sequelize.transaction(async (transaction) => {
-        await queryInterface.sequelize.query(RESTORE_COLUMN_TYPE, { transaction });
+        await queryInterface.sequelize.query(ROLLBACK_COLUMN_TYPE, { transaction });
     }),
 };


### PR DESCRIPTION
#### I DON'T have JIRA ticket
- [x] explain what this PR does
- [ ] if it is a new feature, explain how you plan to use it
- [ ] tests are added
- [ ] documentation was updated or added

Notable changes for users:
- NA

Notable changes for developers:
- NA

Changes made to the database:
- Change type of reconstructed_events_count in data_passes_versions table to hold bigger numbers
