### PR TITLE
[OGUI-1449] Use BIGINT for reconstructedEventsCount

### DIFF
--- a/lib/database/migrations/v1/20250612095121-change-reconstructed-events-to-bigint.js
+++ b/lib/database/migrations/v1/20250612095121-change-reconstructed-events-to-bigint.js
@@ -15,11 +15,11 @@
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
-   up: async (queryInterface, Sequelize) => await queryInterface.changeColumn('data_pass_versions', 'reconstructed_events_count', {
-      type: Sequelize.BIGINT,
+    up: async (queryInterface, Sequelize) => await queryInterface.changeColumn('data_pass_versions', 'reconstructed_events_count', {
+        type: Sequelize.BIGINT,
     }),
 
-  down: async (queryInterface, Sequelize) => await queryInterface.changeColumn('data_pass_versions', 'reconstructed_events_count', {
-      type: Sequelize.INTEGER,
-    })
+    down: async (queryInterface, Sequelize) => await queryInterface.changeColumn('data_pass_versions', 'reconstructed_events_count', {
+        type: Sequelize.INTEGER,
+    }),
 };

--- a/lib/database/migrations/v1/20250612095121-change-reconstructed-events-to-bigint.js
+++ b/lib/database/migrations/v1/20250612095121-change-reconstructed-events-to-bigint.js
@@ -15,27 +15,11 @@
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
-  async up (queryInterface, Sequelize) {
-    /**
-     * Add altering commands here.
-     *
-     * Example:
-     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
-     */
-    await queryInterface.changeColumn('data_pass_versions', 'reconstructed_events_count', {
+   up: async (queryInterface, Sequelize) => await queryInterface.changeColumn('data_pass_versions', 'reconstructed_events_count', {
       type: Sequelize.BIGINT,
-    });
-  },
+    }),
 
-  async down (queryInterface, Sequelize) {
-    /**
-     * Add reverting commands here.
-     *
-     * Example:
-     * await queryInterface.dropTable('users');
-     */
-    await queryInterface.changeColumn('data_pass_versions', 'reconstructed_events_count', {
+  down: async (queryInterface, Sequelize) => await queryInterface.changeColumn('data_pass_versions', 'reconstructed_events_count', {
       type: Sequelize.INTEGER,
-    });
-  }
+    })
 };

--- a/lib/database/migrations/v1/20250612095121-change-reconstructed-events-to-bigint.js
+++ b/lib/database/migrations/v1/20250612095121-change-reconstructed-events-to-bigint.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright CERN and copyright holders of ALICE O2. This software is
+ * distributed under the terms of the GNU General Public License v3 (GPL
+ * Version 3), copied verbatim in the file "COPYING".
+ *
+ * See http://alice-o2.web.cern.ch/license for full licensing information.
+ *
+ * In applying this license CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+    await queryInterface.changeColumn('data_pass_versions', 'reconstructed_events_count', {
+      type: Sequelize.BIGINT,
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+    await queryInterface.changeColumn('data_pass_versions', 'reconstructed_events_count', {
+      type: Sequelize.INTEGER,
+    });
+  }
+};

--- a/lib/database/models/dataPassVersion.js
+++ b/lib/database/models/dataPassVersion.js
@@ -32,7 +32,7 @@ module.exports = (sequelize) => {
                 type: Sequelize.BIGINT,
             },
             reconstructedEventsCount: {
-                type: Sequelize.INTEGER,
+                type: Sequelize.BIGINT,
             },
             lastSeen: {
                 type: Sequelize.INTEGER,

--- a/lib/domain/entities/DataPassVersion.js
+++ b/lib/domain/entities/DataPassVersion.js
@@ -18,7 +18,7 @@
  * @property {number} dataPassId
  * @property {string} description
  * @property {number} outputSize
- * @property {number} reconstructedEventsCount
+ * @property {number} reconstructedEventsCount - expected to be up to a value of 1e13, thus BIGINT definition is needed in SQL but not in JS
  * @property {number} lastSeen
  * @property {boolean} deletedFromMonAlisa
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aliceo2/bookkeeping",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aliceo2/bookkeeping",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "bundleDependencies": [
         "@aliceo2/web-ui",
         "@grpc/grpc-js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliceo2/bookkeeping",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "author": "ALICEO2",
   "scripts": {
     "coverage": "nyc npm test && npm run coverage:report",


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- N/A

Notable changes for developers:
- `reconstructedEventsCount` is expected to be up to a value of 1e13, thus BIGINT definition is needed in SQL. 

Changes made to the database:
-
