### PR TITLE
[O2B-1452] Add filter option by creation date interval for retrieving environments

### DIFF
--- a/lib/domain/dtos/GetAllEnvironmentsDto.js
+++ b/lib/domain/dtos/GetAllEnvironmentsDto.js
@@ -13,6 +13,7 @@
 
 const Joi = require('joi');
 const PaginationDto = require('./PaginationDto');
+const { FromToFilterDto } = require('./filters/FromToFilterDto');
 
 /**
  * Separate filter DTO for get all environments, because EnvironmentsFilterDto
@@ -23,6 +24,7 @@ const FilterDto = Joi.object({
     currentStatus: Joi.string().trim().optional(),
     statusHistory: Joi.string().trim().optional(),
     runNumbers: Joi.string().trim().optional(),
+    created: FromToFilterDto,
 });
 
 const QueryDto = Joi.object({

--- a/lib/usecases/environment/GetAllEnvironmentsUseCase.js
+++ b/lib/usecases/environment/GetAllEnvironmentsUseCase.js
@@ -85,9 +85,16 @@ class GetAllEnvironmentsUseCase {
                 currentStatus: currentStatusExpression,
                 statusHistory,
                 runNumbers: runNumbersExpression,
+                created,
             } = filter;
 
             const filterQueryBuilder = prepareQueryBuilder();
+
+            if (created) {
+                const from = created.from != null ? created.from : 0;
+                const to = created.to != null ? created.to : Date.now();
+                filterQueryBuilder.where('createdAt').between(from, to);
+            }
 
             if (idsExpression) {
                 const filters = idsExpression.split(',').map((id) => id.trim());
@@ -167,12 +174,18 @@ class GetAllEnvironmentsUseCase {
             }
 
             const filteredEnvironmentsIds = (await EnvironmentRepository.findAll(filterQueryBuilder)).map(({ id }) => id);
+            // If no environments match the filter, return an empty result
+            if (filteredEnvironmentsIds.length === 0) {
+                return {
+                    count: 0,
+                    environments: [],
+                };
+            }
             fetchQueryBuilder.where('id').oneOf(filteredEnvironmentsIds);
         }
 
         fetchQueryBuilder.include({ association: 'runs' });
         fetchQueryBuilder.include({ association: 'historyItems' });
-
         const { count, rows } = await EnvironmentRepository.findAndCountAll(fetchQueryBuilder);
         return {
             count,

--- a/lib/usecases/environment/GetAllEnvironmentsUseCase.js
+++ b/lib/usecases/environment/GetAllEnvironmentsUseCase.js
@@ -91,8 +91,8 @@ class GetAllEnvironmentsUseCase {
             const filterQueryBuilder = prepareQueryBuilder();
 
             if (created) {
-                const from = created.from != null ? created.from : 0;
-                const to = created.to != null ? created.to : Date.now();
+                const from = created.from !== undefined ? created.from : 0;
+                const to = created.to !== undefined ? created.to : Date.now();
                 filterQueryBuilder.where('createdAt').between(from, to);
             }
 

--- a/test/api/environments.test.js
+++ b/test/api/environments.test.js
@@ -43,7 +43,7 @@ module.exports = () => {
 
             expect(response.status).to.equal(200);
             const environments = response.body.data;
-            expect(environments).to.lengthOf(2); // Assuming all environments were created in 2023
+            expect(environments).to.lengthOf(2);
             expect(environments[0].id).to.equal('TDI59So3d');
             expect(environments[1].id).to.equal('EIDO13i3D');
         });
@@ -54,7 +54,7 @@ module.exports = () => {
 
             expect(response.status).to.equal(200);
             const environments = response.body.data;
-            expect(environments).to.lengthOf(3); // Assuming all environments were created in 2023
+            expect(environments).to.lengthOf(3);
             expect(environments[0].id).to.equal('CmCvjNbg');
             expect(environments[1].id).to.equal('TDI59So3d');
             expect(environments[2].id).to.equal('EIDO13i3D');
@@ -66,7 +66,7 @@ module.exports = () => {
 
             expect(response.status).to.equal(200);
             const environments = response.body.data;
-            expect(environments).to.lengthOf(8); // Assuming all environments were created in 2023
+            expect(environments).to.lengthOf(8);
             expect(environments[0].id).to.equal('TDI59So3d');
             expect(environments[1].id).to.equal('EIDO13i3D');
             expect(environments[2].id).to.equal('KGIS12DS');

--- a/test/api/environments.test.js
+++ b/test/api/environments.test.js
@@ -77,6 +77,15 @@ module.exports = () => {
             expect(environments[7].id).to.equal('eZF99lH6');
         });
 
+        it('should successfully return no environments for filter not matching', async () => {
+            const from = Date.now();
+            const response = await request(server).get(`/api/environments?filter[created][from]=${from}`);
+
+            expect(response.status).to.equal(200);
+            const environments = response.body.data;
+            expect(environments).to.lengthOf(0);
+        });
+
         it('should successfully apply filter for environments ids', async () => {
             const response = await request(server).get('/api/environments?filter[ids]=8E4aZTjY');
 

--- a/test/api/environments.test.js
+++ b/test/api/environments.test.js
@@ -36,6 +36,49 @@ module.exports = () => {
             expect(environments[0].id).to.equal('CmCvjNbg');
         });
 
+        it('should successfully return environments that were created between two provided dates', async () => {
+            const from = new Date('2019-08-09 15:50:00').getTime();
+            const to = new Date('2019-08-09 19:00:00').getTime();
+            const response = await request(server).get(`/api/environments?filter[created][from]=${from}&filter[created][to]=${to}`);
+
+            expect(response.status).to.equal(200);
+            const environments = response.body.data;
+            expect(environments).to.lengthOf(2); // Assuming all environments were created in 2023
+            expect(environments[0].id).to.equal('TDI59So3d');
+            expect(environments[1].id).to.equal('EIDO13i3D');
+        });
+
+        it('should successfully return environments that were created from provided date', async () => {
+            const from = new Date('2019-08-09 15:50:00').getTime();
+            const response = await request(server).get(`/api/environments?filter[created][from]=${from}`);
+
+            expect(response.status).to.equal(200);
+            const environments = response.body.data;
+            expect(environments).to.lengthOf(3); // Assuming all environments were created in 2023
+            expect(environments[0].id).to.equal('CmCvjNbg');
+            expect(environments[1].id).to.equal('TDI59So3d');
+            expect(environments[2].id).to.equal('EIDO13i3D');
+        });
+
+        it('should successfully return environments that were created to provided date', async () => {
+            const to = new Date('2019-08-09 19:00:00').getTime();
+            const response = await request(server).get(`/api/environments?filter[created][to]=${to}`);
+
+            expect(response.status).to.equal(200);
+            const environments = response.body.data;
+            console.log('-------- Environments:');
+            console.log(environments);
+            expect(environments).to.lengthOf(8); // Assuming all environments were created in 2023
+            expect(environments[0].id).to.equal('TDI59So3d');
+            expect(environments[1].id).to.equal('EIDO13i3D');
+            expect(environments[2].id).to.equal('KGIS12DS');
+            expect(environments[3].id).to.equal('VODdsO12d');
+            expect(environments[4].id).to.equal('GIDO1jdkD');
+            expect(environments[5].id).to.equal('8E4aZTjY');
+            expect(environments[6].id).to.equal('Dxi029djX');
+            expect(environments[7].id).to.equal('eZF99lH6');
+        });
+
         it('should successfully apply filter for environments ids', async () => {
             const response = await request(server).get('/api/environments?filter[ids]=8E4aZTjY');
 

--- a/test/api/environments.test.js
+++ b/test/api/environments.test.js
@@ -66,8 +66,6 @@ module.exports = () => {
 
             expect(response.status).to.equal(200);
             const environments = response.body.data;
-            console.log('-------- Environments:');
-            console.log(environments);
             expect(environments).to.lengthOf(8); // Assuming all environments were created in 2023
             expect(environments[0].id).to.equal('TDI59So3d');
             expect(environments[1].id).to.equal('EIDO13i3D');

--- a/test/lib/usecases/environment/GetAllEnvironmentsUseCase.test.js
+++ b/test/lib/usecases/environment/GetAllEnvironmentsUseCase.test.js
@@ -190,4 +190,12 @@ module.exports = () => {
         expect(environments).to.be.an('array');
         expect(environments.length).to.be.equal(9); // Environments from seeders
     });
+
+    it('should successfully return empty environment array if filter does not match', async () => {
+        const from = Date.now() - 10; 
+        getAllEnvsDto.query = { filter: { created: { from } } };
+        const { environments } = await new GetAllEnvironmentsUseCase().execute(getAllEnvsDto);
+        expect(environments).to.be.an('array');
+        expect(environments.length).to.be.equal(0); // Environments from seeders
+    });
 };

--- a/test/lib/usecases/environment/GetAllEnvironmentsUseCase.test.js
+++ b/test/lib/usecases/environment/GetAllEnvironmentsUseCase.test.js
@@ -161,4 +161,33 @@ module.exports = () => {
         // Should include all environments with run numbers containing the substring 10
         expect(environments.map(({ id }) => id)).to.have.members(['TDI59So3d', 'Dxi029djX']);
     });
+
+    it('should successfully filter environments on created from and to', async () => {
+        const from = Date.now() - 24 * 60 * 60 * 1000; // environment from 24h ago which was created by CreateEnvironmentUseCase.test.js
+        const to = Date.now() - 10;
+        getAllEnvsDto.query = { filter: { created: { from, to } } };
+        const { environments } = await new GetAllEnvironmentsUseCase().execute(getAllEnvsDto);
+        expect(environments).to.be.an('array');
+        expect(environments.length).to.be.equal(2);
+        expect(environments[0].id).to.be.equal('newId');
+        expect(environments[1].id).to.be.equal('SomeId');
+    });
+
+    it('should successfully filter environments on created from', async () => {
+        const from = Date.now() - 24 * 60 * 60 * 1000; // environment from 24h ago which was created by CreateEnvironmentUseCase.test.js
+        getAllEnvsDto.query = { filter: { created: { from } } };
+        const { environments } = await new GetAllEnvironmentsUseCase().execute(getAllEnvsDto);
+        expect(environments).to.be.an('array');
+        expect(environments.length).to.be.equal(2);
+        expect(environments[0].id).to.be.equal('newId');
+        expect(environments[1].id).to.be.equal('SomeId');
+    });
+
+    it('should successfully filter environments on created to', async () => {
+        const to = Date.now() - 24 * 60 * 60 * 1000; // environment until 24h are created by seeders
+        getAllEnvsDto.query = { filter: { created: { to } } };
+        const { environments } = await new GetAllEnvironmentsUseCase().execute(getAllEnvsDto);
+        expect(environments).to.be.an('array');
+        expect(environments.length).to.be.equal(9); // Environments from seeders
+    });
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- GET API endpoint `environments` now allows for retrieving them filtered based on creation date time interval [from, to]

Notable changes for developers:
-

Changes made to the database:
-
