### PR TITLE
[O2B-1453] Add unit for beta start value labels

### DIFF
--- a/lib/domain/entities/Run.js
+++ b/lib/domain/entities/Run.js
@@ -45,7 +45,7 @@
  * @property {number|null} fillNumber
  * @property {number|null} lhcBeamEnergy
  * @property {string|null} lhcBeamMode
- * @property {number|null} lhcBetaStar
+ * @property {number|null} lhcBetaStar - as received from BKP-LHC-Client, value in m
  * @property {number|null} aliceL3Current
  * @property {number|null} aliceDipoleCurrent
  * @property {string|null} aliceL3Polarity

--- a/lib/public/views/Runs/Details/runDetailsComponent.js
+++ b/lib/public/views/Runs/Details/runDetailsComponent.js
@@ -494,7 +494,7 @@ export const runDetailsComponent = (runDetailsModel, router) => runDetailsModel.
                                                 run.lhcFill?.fillingSchemeName,
                                             ]),
                                             h('', [
-                                                h('strong', 'Beta Star: '),
+                                                h('strong', 'Beta Star (m): '),
                                                 run.lhcBetaStar ?? '-',
                                             ]),
                                             h('', [


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- LHC BetaStar value will display the unit in the label

Notable changes for developers:
- the LHC beta star value will have a 10x increase but this will be done on the BKP-LHC-Client side and manually update the previous runs stored in DB

Changes made to the database:
-
