### PR TITLE
[O2B-1577] Rename include.byName filter to permittedNonPhysicsNames

### DIFF
--- a/lib/domain/enums/NonPhysicsProductionsNamesWords.js
+++ b/lib/domain/enums/NonPhysicsProductionsNamesWords.js
@@ -23,3 +23,5 @@ const NonPhysicsProductionsNamesWords = Object.freeze({
 module.exports.NonPhysicsProductionsNamesWords = NonPhysicsProductionsNamesWords;
 
 module.exports.NON_PHYSICS_PRODUCTIONS_NAMES_WORDS = Object.values(NonPhysicsProductionsNamesWords);
+
+module.exports.NON_PHYSICS_PRODUCTIONS_NAMES_TOTAL_LENGTH = Object.values(NonPhysicsProductionsNamesWords).join().length;

--- a/lib/domain/enums/NonPhysicsProductionsNamesWords.js
+++ b/lib/domain/enums/NonPhysicsProductionsNamesWords.js
@@ -24,4 +24,4 @@ module.exports.NonPhysicsProductionsNamesWords = NonPhysicsProductionsNamesWords
 
 module.exports.NON_PHYSICS_PRODUCTIONS_NAMES_WORDS = Object.values(NonPhysicsProductionsNamesWords);
 
-module.exports.NON_PHYSICS_PRODUCTIONS_NAMES_TOTAL_LENGTH = Object.values(NonPhysicsProductionsNamesWords).join().length;
+module.exports.NON_PHYSICS_PRODUCTIONS_NAMES_TOTAL_LENGTH = Object.values(NonPhysicsProductionsNamesWords).join(',').length;

--- a/lib/public/components/Filters/RunsFilter/DetectorsFilterModel.js
+++ b/lib/public/components/Filters/RunsFilter/DetectorsFilterModel.js
@@ -62,7 +62,7 @@ export class DetectorsFilterModel extends FilterModel {
             operator: this._combinationOperatorModel.current,
         };
         if (!this.isNone()) {
-            normalized.values = this._dropdownModel.selected.join();
+            normalized.values = this._dropdownModel.normalized;
         }
         return normalized;
     }

--- a/lib/public/components/common/selection/SelectionModel.js
+++ b/lib/public/components/common/selection/SelectionModel.js
@@ -373,6 +373,6 @@ export class SelectionModel extends Observable {
      * @return {string|string[]|boolean|boolean[]|number|number[]|SelectionOption|SelectionOption[]} the normalized value
      */
     get normalized() {
-        return (this._allowEmpty || this._multiple) ? this.selected.join() : this.current;
+        return (this._allowEmpty || this._multiple) ? this.selected.join(',') : this.current;
     }
 }

--- a/lib/public/views/DataPasses/ActiveColumns/dataPassesActiveColumns.js
+++ b/lib/public/views/DataPasses/ActiveColumns/dataPassesActiveColumns.js
@@ -105,7 +105,7 @@ export const dataPassesActiveColumns = {
 
     nonPhysicsProductions: {
         name: 'Include nonphysics productions',
-        filter: (filteringModel) => checkboxes(filteringModel.get('include[byName]').selectionModel),
+        filter: (filteringModel) => checkboxes(filteringModel.get('permittedNonPhysicsNames').selectionModel),
         visible: false,
     },
 };

--- a/lib/public/views/DataPasses/ActiveColumns/dataPassesActiveColumns.js
+++ b/lib/public/views/DataPasses/ActiveColumns/dataPassesActiveColumns.js
@@ -102,7 +102,7 @@ export const dataPassesActiveColumns = {
 
     nonPhysicsProductions: {
         name: 'Include nonphysics productions',
-        filter: (filteringModel) => checkboxes(filteringModel.get('include[byName]')),
+        filter: (filteringModel) => checkboxes(filteringModel.get('permittedNonPhysicsNames')),
         visible: false,
     },
 };

--- a/lib/public/views/DataPasses/DataPassesOverviewModel.js
+++ b/lib/public/views/DataPasses/DataPassesOverviewModel.js
@@ -27,7 +27,7 @@ export class DataPassesOverviewModel extends OverviewPageModel {
         super();
         this._filteringModel = new FilteringModel({
             names: new TextTokensFilterModel(),
-            'include[byName]': new SelectionFilterModel({
+            permittedNonPhysicsNames: new SelectionFilterModel({
                 availableOptions: NON_PHYSICS_PRODUCTIONS_NAMES_WORDS.map((word) => ({ label: word.toUpperCase(), value: word })),
             }),
         });

--- a/lib/public/views/DataPasses/DataPassesOverviewModel.js
+++ b/lib/public/views/DataPasses/DataPassesOverviewModel.js
@@ -31,7 +31,7 @@ export class DataPassesOverviewModel extends OverviewPageModel {
             router,
             {
                 names: new TextTokensFilterModel(),
-                'include[byName]': new SelectionModel({
+                permittedNonPhysicsNames: new SelectionModel({
                     availableOptions: NON_PHYSICS_PRODUCTIONS_NAMES_WORDS.map((word) => ({ label: word.toUpperCase(), value: word })),
                 }),
             },

--- a/lib/server/controllers/dataPasses.controller.js
+++ b/lib/server/controllers/dataPasses.controller.js
@@ -34,17 +34,15 @@ const listDataPassesHandler = async (req, res) => {
                 lhcPeriodIds: Joi.array().items(Joi.number()),
                 ids: Joi.array().items(Joi.number()),
                 names: Joi.array().items(Joi.string()),
-                include: Joi.object({ byName: Joi.string().custom((value, helper) => {
-                    if (value.length > 10) {
-                        return helper.error('byName cannot have more than 10 characters');
-                    }
-                    const nameTokens = value?.split(',');
+                // 'debug,test' or the reverse have a length of 10
+                permittedNonPhysicsNames: Joi.string().max(10).custom((value, helper) => {
+                    const nameTokens = value.split(',');
                     const allTokensCorrect = nameTokens.every((token) => NON_PHYSICS_PRODUCTIONS_NAMES_WORDS.includes(token));
                     if (!allTokensCorrect) {
-                        return helper.error(`All byName must comma delimited list of ${NON_PHYSICS_PRODUCTIONS_NAMES_WORDS}`);
+                        return helper.error(`All permittedNonPhysicsNames must comma delimited list of ${NON_PHYSICS_PRODUCTIONS_NAMES_WORDS}`);
                     }
                     return nameTokens;
-                }) }),
+                }),
             },
             page: PaginationDto,
             sort: DtoFactory.order(['id', 'name']),

--- a/lib/server/controllers/dataPasses.controller.js
+++ b/lib/server/controllers/dataPasses.controller.js
@@ -21,7 +21,10 @@ const { dtoValidator } = require('../utilities/dtoValidator.js');
 const { countedItemsToHttpView } = require('../utilities/countedItemsToHttpView.js');
 const { updateExpressResponseFromNativeError } = require('../express/updateExpressResponseFromNativeError');
 const PaginationDto = require('../../domain/dtos/PaginationDto.js');
-const { NON_PHYSICS_PRODUCTIONS_NAMES_WORDS } = require('../../domain/enums/NonPhysicsProductionsNamesWords.js');
+const {
+    NON_PHYSICS_PRODUCTIONS_NAMES_WORDS,
+    NON_PHYSICS_PRODUCTIONS_NAMES_TOTAL_LENGTH,
+} = require('../../domain/enums/NonPhysicsProductionsNamesWords.js');
 
 /**
  * List All DataPasses with statistics
@@ -34,8 +37,7 @@ const listDataPassesHandler = async (req, res) => {
                 lhcPeriodIds: Joi.array().items(Joi.number()),
                 ids: Joi.array().items(Joi.number()),
                 names: Joi.array().items(Joi.string()),
-                // 'debug,test' or the reverse have a length of 10
-                permittedNonPhysicsNames: Joi.string().max(10).custom((value, helper) => {
+                permittedNonPhysicsNames: Joi.string().max(NON_PHYSICS_PRODUCTIONS_NAMES_TOTAL_LENGTH).custom((value, helper) => {
                     const nameTokens = value.split(',');
                     const allTokensCorrect = nameTokens.every((token) => NON_PHYSICS_PRODUCTIONS_NAMES_WORDS.includes(token));
                     if (!allTokensCorrect) {

--- a/lib/server/services/dataPasses/DataPassService.js
+++ b/lib/server/services/dataPasses/DataPassService.js
@@ -88,12 +88,24 @@ class DataPassService {
      * @returns {Promise<CountedItems<DataPass>>} result
      */
     async getAll({
-        filter,
+        filter = {},
         limit,
         offset,
         sort,
     } = {}) {
         const queryBuilder = this.prepareQueryBuilder();
+
+        /**
+         * @typedef
+         * @property {object} filter
+         * @property {number[]} [filter.lhcPeriodIds] lhcPeriod identifier to filter with
+         * @property {number[]} [filter.simulationPassIds] simulationPass identifier to filter with
+         * @property {number[]} [filter.ids] data passes identifier to filter with
+         * @property {string[]} [filter.names] data passes names to filter with
+         * @property {boolean}  [filter.includeByName] list of tokens in data passes names which indicate
+         * a given data pass should not be excluded, possible tokens are 'test', 'debug'.
+         */
+        const { ids, names, permittedNonPhysicsNames = [], lhcPeriodIds, simulationPassIds } = filter;
 
         if (sort) {
             for (const property in sort) {
@@ -108,37 +120,24 @@ class DataPassService {
             queryBuilder.offset(offset);
         }
 
-        if (filter) {
-            /**
-             * @typedef
-             * @property {object} filter
-             * @property {number[]} [filter.lhcPeriodIds] lhcPeriod identifier to filter with
-             * @property {number[]} [filter.simulationPassIds] simulationPass identifier to filter with
-             * @property {number[]} [filter.ids] data passes identifier to filter with
-             * @property {string[]} [filter.names] data passes names to filter with
-             * @property {boolean}  [filter.include.byName] list of tokens in data passes names which indicate
-             * a given data pass should not be excluded, possible tokens are 'test', 'debug'.
-             */
-            const { ids, names, lhcPeriodIds, simulationPassIds } = filter;
-            if (lhcPeriodIds) {
-                queryBuilder.where('lhcPeriodId').oneOf(...lhcPeriodIds);
-            }
-            if (simulationPassIds) {
-                queryBuilder.whereAssociation('anchoredSimulationPasses', 'id').oneOf(...simulationPassIds);
-            }
-            if (ids) {
-                queryBuilder.where('id').oneOf(...ids);
-            }
-            if (names) {
-                queryBuilder.where('name').oneOf(...names);
-            }
+        if (lhcPeriodIds) {
+            queryBuilder.where('lhcPeriodId').oneOf(...lhcPeriodIds);
+        }
+        if (simulationPassIds) {
+            queryBuilder.whereAssociation('anchoredSimulationPasses', 'id').oneOf(...simulationPassIds);
+        }
+        if (ids) {
+            queryBuilder.where('id').oneOf(...ids);
+        }
+        if (names) {
+            queryBuilder.where('name').oneOf(...names);
         }
 
-        const byName = filter?.include?.byName ?? [];
-        if (!byName.includes(NonPhysicsProductionsNamesWords.TEST)) {
+        if (!permittedNonPhysicsNames.includes(NonPhysicsProductionsNamesWords.TEST)) {
             queryBuilder.where('name').not().substring(`\\_${NonPhysicsProductionsNamesWords.TEST}`);
         }
-        if (!byName.includes(NonPhysicsProductionsNamesWords.DEBUG)) {
+
+        if (!permittedNonPhysicsNames.includes(NonPhysicsProductionsNamesWords.DEBUG)) {
             queryBuilder.where('name').not().substring(`\\_${NonPhysicsProductionsNamesWords.DEBUG}`);
         }
 

--- a/lib/server/services/dataPasses/DataPassService.js
+++ b/lib/server/services/dataPasses/DataPassService.js
@@ -102,7 +102,7 @@ class DataPassService {
          * @property {number[]} [filter.simulationPassIds] simulationPass identifier to filter with
          * @property {number[]} [filter.ids] data passes identifier to filter with
          * @property {string[]} [filter.names] data passes names to filter with
-         * @property {boolean}  [filter.includeByName] list of tokens in data passes names which indicate
+         * @property {string[]}  [filter.permittedNonPhysicsNames] list of tokens in data passes names which indicate
          * a given data pass should not be excluded, possible tokens are 'test', 'debug'.
          */
         const { ids, names, permittedNonPhysicsNames = [], lhcPeriodIds, simulationPassIds } = filter;

--- a/test/api/dataPasses.test.js
+++ b/test/api/dataPasses.test.js
@@ -296,13 +296,13 @@ module.exports = () => {
                 });
         });
         it('should successfully include TEST productions', async () => {
-            const response = await request(server).get('/api/dataPasses?filter[lhcPeriodIds][]=2&filter[include][byName]=test');
+            const response = await request(server).get('/api/dataPasses?filter[lhcPeriodIds][]=2&filter[permittedNonPhysicsNames]=test');
             expect(response.status).to.be.equal(200);
             const { data } = await response.body;
             expect(data.map(({ name }) => name)).to.have.all.members(['LHC22b_apass1', 'LHC22b_skimming','LHC22b_apass2_skimmed', 'LHC22b_test']);
         });
         it('should successfully include DEBUG productions', async () => {
-            const response = await request(server).get('/api/dataPasses?filter[lhcPeriodIds][]=2&filter[include][byName]=debug');
+            const response = await request(server).get('/api/dataPasses?filter[lhcPeriodIds][]=2&filter[permittedNonPhysicsNames]=debug');
             expect(response.status).to.be.equal(200);
             const { data } = await response.body;
             expect(data.map(({ name }) => name)).to.have.all.members(['LHC22b_apass1', 'LHC22b_skimming','LHC22b_apass2_skimmed', 'LHC22b_debug']);

--- a/test/public/Filters/filtersToUrl.test.js
+++ b/test/public/Filters/filtersToUrl.test.js
@@ -352,7 +352,7 @@ module.exports = () => {
             "page": "data-passes-per-lhc-period-overview",
             "lhcPeriodId": "2",
             "filter[names][]": "LHC22b_apass1",
-            "filter[include][byName]": "test"
+            "filter[permittedNonPhysicsNames]": "test"
         });
     });
 
@@ -367,7 +367,7 @@ module.exports = () => {
             "page": "data-passes-per-simulation-pass-overview",
             "simulationPassId": "1",
             "filter[names][]": "LHC22b_apass1",
-            "filter[include][byName]": "test"
+            "filter[permittedNonPhysicsNames]": "test"
         });
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please fill up one of the checklist below by changing [ ] to [x].
Remove checklist and/or items that do not apply.
-->

#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- N/A

Notable changes for developers:
- The include.byName filter is now called permittedNonPhysicsNames
- The first ~30 lines of code in datapassService.getAll have been refactored for readability

Changes made to the database:
- N/A
