### PR TITLE
[O2B-1583] Sort lhc period overview page by id and not name

### DIFF
--- a/lib/server/controllers/lhcPeriodStatistics.controller.js
+++ b/lib/server/controllers/lhcPeriodStatistics.controller.js
@@ -42,7 +42,7 @@ const listLhcPeriodStatisticsHandler = async (req, res) => {
     );
     if (validatedDTO) {
         try {
-            const { filter, page: { limit = ApiConfig.pagination.limit, offset } = {}, sort = { name: 'DESC' } } = validatedDTO.query;
+            const { filter, page: { limit = ApiConfig.pagination.limit, offset } = {}, sort = { id: 'DESC' } } = validatedDTO.query;
             const { count, rows: items } = await lhcPeriodStatisticsService.getAllForPhysicsRuns({
                 filter,
                 limit,

--- a/lib/server/services/lhcPeriod/LhcPeriodStatisticsService.js
+++ b/lib/server/services/lhcPeriod/LhcPeriodStatisticsService.js
@@ -85,11 +85,13 @@ class LhcPeriodStatisticsService {
         sort,
     } = {}) {
         const queryBuilder = this.prepareQueryBuilder();
-
         if (sort) {
             for (const property in sort) {
                 let expression;
                 switch (property) {
+                    case 'id':
+                        expression = (sequelize) => sequelize.col('`lhcPeriod`.`id`');;
+                        break;
                     case 'name':
                         expression = (sequelize) => sequelize.col('`lhcPeriod`.`name`');
                         break;

--- a/lib/server/services/lhcPeriod/LhcPeriodStatisticsService.js
+++ b/lib/server/services/lhcPeriod/LhcPeriodStatisticsService.js
@@ -21,6 +21,12 @@ const { NotFoundError } = require('../../errors/NotFoundError');
 const { RunDefinition } = require('../../../domain/enums/RunDefinition.js');
 const { NonPhysicsProductionsNamesWords } = require('../../../domain/enums/NonPhysicsProductionsNamesWords.js');
 
+const sortExpressionMap = {
+    name: (sequelize) => sequelize.col('`lhcPeriod`.`name`'),
+    year: (sequelize) => sequelize.literal('SUBSTRING(lhcPeriod.name, 4, 2)'),
+    pdpBeamTypes: (sequelize) => sequelize.literal('pdpBeamTypes'),
+};
+
 /**
  * @typedef LhcPeriodIdentifier object to uniquely identify a lhc period
  * @property {string} [name] the lhc period name
@@ -87,22 +93,7 @@ class LhcPeriodStatisticsService {
         const queryBuilder = this.prepareQueryBuilder();
         if (sort) {
             for (const property in sort) {
-                let expression;
-                switch (property) {
-                    case 'id':
-                        expression = (sequelize) => sequelize.col('`lhcPeriod`.`id`');;
-                        break;
-                    case 'name':
-                        expression = (sequelize) => sequelize.col('`lhcPeriod`.`name`');
-                        break;
-                    case 'year':
-                        expression = (sequelize) => sequelize.literal('SUBSTRING(lhcPeriod.name, 4, 2)');
-                        break;
-                    case 'pdpBeamTypes':
-                        expression = (sequelize) => sequelize.literal('pdpBeamTypes');
-                        break;
-                }
-
+                const expression = sortExpressionMap[property];
                 queryBuilder.orderBy(expression ?? property, sort[property]);
             }
         }


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- `unknown` datapass will not be displayed as first anymore

Notable changes for developers:
- page for `lhcPeriodOverview` was sorted by name because the naming convention implies also the chronological order of the periods. Because of this, 'u'>'l' was also at top.
- now, sorting is done by the period id, which as it is an incremental column, also shows chornological order of data pass

Changes made to the database:
- N/A
