### PR TITLE
[O2B-1527] Display a QC Flag from/to with milliseconds 

### DIFF
--- a/lib/public/utilities/dateUtils.mjs
+++ b/lib/public/utilities/dateUtils.mjs
@@ -36,6 +36,21 @@ export const getLocaleDateAndTime = (timestamp, options) => {
 };
 
 /**
+ * Returns the english-formatted date and time components of a given timestamp, with milliseconds included in the time
+ * @param {number} timestamp the UNIX timestamp (in ms) to format
+ * @return {{date: string, time: string}} the formatted components
+ */
+export const getLocaleDateAndTimeWithMilliseconds = (timestamp) => ({
+    date: getLocaleDateAndTime(timestamp).date,
+    time: new Date(timestamp).toLocaleTimeString(LOCALE_DATE_FORMAT, {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        fractionalSecondDigits: 3,
+    }),
+});
+
+/**
  * Returns the date corresponding to the start of the given day (if null, start of today)
  *
  * @param {number} [day] the day for which the start date should be returned (between 1 and 31)

--- a/lib/public/utilities/formatting/formatTimestamp.js
+++ b/lib/public/utilities/formatting/formatTimestamp.js
@@ -13,7 +13,7 @@
 
 import { h } from '/js/src/index.js';
 import { userPreferencesStore } from '../userPreferencesStore.js';
-import { getLocaleDateAndTime } from '../dateUtils.mjs';
+import { getLocaleDateAndTime, getLocaleDateAndTimeWithMilliseconds } from '../dateUtils.mjs';
 
 /**
  * Format the given timestamp in the common format, i.e. en-GB locale with short date and medium time
@@ -21,10 +21,11 @@ import { getLocaleDateAndTime } from '../dateUtils.mjs';
  * @param {number|null} timestamp the timestamp to format (in milliseconds)
  * @param {boolean} [inline] if true, the date and time will be returned as a string. Else, a component will be returned and date and time are
  *     separated by a newline
+ * @param {boolean} [displayMilliseconds] if true, the time will include milliseconds
  *
  * @return {vnode|string} the formatted timestamp
  */
-export const formatTimestamp = (timestamp, inline = true) => {
+export const formatTimestamp = (timestamp, inline = true, displayMilliseconds = false) => {
     if (timestamp === null || timestamp === undefined) {
         return '-';
     }
@@ -33,7 +34,9 @@ export const formatTimestamp = (timestamp, inline = true) => {
         return `${timestamp}`;
     }
 
-    const { date, time } = getLocaleDateAndTime(timestamp);
+    const { date, time } = displayMilliseconds
+        ? getLocaleDateAndTimeWithMilliseconds(timestamp)
+        : getLocaleDateAndTime(timestamp);
 
     if (inline) {
         return `${date}, ${time}`;

--- a/lib/public/views/QcFlags/details/qcFlagDetailsConfiguration.js
+++ b/lib/public/views/QcFlags/details/qcFlagDetailsConfiguration.js
@@ -14,6 +14,8 @@
 import { h } from '/js/src/index.js';
 import { frontLink } from '../../../components/common/navigation/frontLink.js';
 import { formatTimestamp } from '../../../utilities/formatting/formatTimestamp.js';
+import { formatQcFlagStart } from '../format/formatQcFlagStart.js';
+import { formatQcFlagEnd } from '../format/formatQcFlagEnd.js';
 import { qcFlagTypeColoredBadge } from '../../../components/qcFlags/qcFlagTypeColoredBadge.js';
 import { formatQcFlagCreatedBy } from '../format/formatQcFlagCreatedBy.js';
 
@@ -38,12 +40,12 @@ export const qcFlagDetailsConfiguration = {
     from: {
         name: 'From',
         visible: true,
-        format: (timestamp) => formatTimestamp(timestamp),
+        format: (timestamp) => formatQcFlagStart({ from: timestamp }, true),
     },
     to: {
         name: 'To',
         visible: true,
-        format: (timestamp) => formatTimestamp(timestamp),
+        format: (timestamp) => formatQcFlagEnd({ to: timestamp }, true),
     },
     verified: {
         name: 'Verified',

--- a/lib/public/views/QcFlags/format/formatQcFlagEnd.js
+++ b/lib/public/views/QcFlags/format/formatQcFlagEnd.js
@@ -11,18 +11,18 @@
  * or submit itself to any jurisdiction.
  */
 
-import { formatTimestamp } from '../../../utilities/formatting/formatTimestamp.js';
+import { formatQcFlagTimestamp } from './formatQcFlagTimestamp.js';
 
 /**
  * Format QC flag `to` timestamp
  *
  * @param {QcFlag} qcFlag QC flag
- * @param {boolean} inline if true, date and time are on a single line
+ * @param {boolean} inline preserved for compatibility with existing callers
  * @return {Component} formatted `to` timestamp
  */
 export const formatQcFlagEnd = ({ from, to }, inline = false) => {
     if (to) {
-        return formatTimestamp(to, inline);
+        return formatQcFlagTimestamp(to, inline);
     } else {
         return from
             ? 'Until run end'

--- a/lib/public/views/QcFlags/format/formatQcFlagStart.js
+++ b/lib/public/views/QcFlags/format/formatQcFlagStart.js
@@ -17,7 +17,7 @@ import { formatQcFlagTimestamp } from './formatQcFlagTimestamp.js';
  * Format QC flag `from` timestamp
  *
  * @param {QcFlag} qcFlag QC flag
- * @param {boolean} [inline=false] if true, the date and time will be returned as a string. Else, a component will be returned 
+ * @param {boolean} [inline=false] if true, the date and time will be returned as a string. Else, a component will be returned
  * with date and time being separated by a newline
  * @return {Component} formatted `from` timestamp
  */

--- a/lib/public/views/QcFlags/format/formatQcFlagTimestamp.js
+++ b/lib/public/views/QcFlags/format/formatQcFlagTimestamp.js
@@ -18,7 +18,7 @@ import { getLocaleDateAndTimeWithMilliseconds } from '../../../utilities/dateUti
  * Format QC flag timestamp with de-emphasized date and emphasized milliseconds.
  *
  * @param {number} timestamp timestamp to format
- * @param {boolean} [inline=false] if true, the date and time will be returned as a string. Else, a component will be returned 
+ * @param {boolean} [inline=false] if true, the date and time will be returned as a string. Else, a component will be returned
  * with date and time being separated by a newline
  * @return {Component} formatted timestamp
  */

--- a/lib/public/views/QcFlags/format/formatQcFlagTimestamp.js
+++ b/lib/public/views/QcFlags/format/formatQcFlagTimestamp.js
@@ -11,22 +11,23 @@
  * or submit itself to any jurisdiction.
  */
 
-import { formatQcFlagTimestamp } from './formatQcFlagTimestamp.js';
+import { h } from '/js/src/index.js';
+import { getLocaleDateAndTimeWithMilliseconds } from '../../../utilities/dateUtils.mjs';
 
 /**
- * Format QC flag `from` timestamp
+ * Format QC flag timestamp with de-emphasized date and emphasized milliseconds.
  *
- * @param {QcFlag} qcFlag QC flag
+ * @param {number} timestamp timestamp to format
  * @param {boolean} [inline=false] if true, the date and time will be returned as a string. Else, a component will be returned 
  * with date and time being separated by a newline
- * @return {Component} formatted `from` timestamp
+ * @return {Component} formatted timestamp
  */
-export const formatQcFlagStart = ({ from, to }, inline = false) => {
-    if (from) {
-        return formatQcFlagTimestamp(from, inline);
-    } else {
-        return to
-            ? 'Since run start'
-            : 'Whole run coverage';
+export const formatQcFlagTimestamp = (timestamp, inline = false) => {
+    const { date, time } = getLocaleDateAndTimeWithMilliseconds(timestamp);
+    const [, wholeSeconds, milliseconds] = time.match(/^(.*)(\.\d{3})$/);
+
+    if (inline) {
+        return `${date}, ${wholeSeconds}${milliseconds}`;
     }
+    return h('', [h('.gray-darker', `${date}, `), wholeSeconds, h('strong', milliseconds)]);
 };

--- a/test/public/qcFlags/detailsForDataPass.test.js
+++ b/test/public/qcFlags/detailsForDataPass.test.js
@@ -82,8 +82,8 @@ module.exports = () => {
         await expectInnerText(page, '#qc-flag-details-runNumber', 'Run:\n106');
         await expectInnerText(page, '#qc-flag-details-dplDetector', 'Detector:\nCPV');
         await expectInnerText(page, '#qc-flag-details-flagType', 'Type:\nLimited Acceptance MC Reproducible');
-        await expectInnerText(page, '#qc-flag-details-from', 'From:\n08/08/2019, 22:43:20');
-        await expectInnerText(page, '#qc-flag-details-to', 'To:\n09/08/2019, 04:16:40');
+        await expectInnerText(page, '#qc-flag-details-from', 'From:\n08/08/2019, 22:43:20.000');
+        await expectInnerText(page, '#qc-flag-details-to', 'To:\n09/08/2019, 04:16:40.000');
         await expectInnerText(page, '#qc-flag-details-createdBy', 'Created by:\nJohn Doe');
         await expectInnerText(page, '#qc-flag-details-createdAt', 'Created at:\n13/02/2024, 11:57:16');
         await expectInnerText(page, '.panel div', 'Some qc comment 1');

--- a/test/public/qcFlags/detailsForSimulationPass.test.js
+++ b/test/public/qcFlags/detailsForSimulationPass.test.js
@@ -97,8 +97,8 @@ module.exports = () => {
         await expectInnerText(page, '#qc-flag-details-runNumber', 'Run:\n106');
         await expectInnerText(page, '#qc-flag-details-dplDetector', 'Detector:\nCPV');
         await expectInnerText(page, '#qc-flag-details-flagType', 'Type:\nBad');
-        await expectInnerText(page, '#qc-flag-details-from', 'From:\n08/08/2019, 13:46:40');
-        await expectInnerText(page, '#qc-flag-details-to', 'To:\n09/08/2019, 07:50:00');
+        await expectInnerText(page, '#qc-flag-details-from', 'From:\n08/08/2019, 13:46:40.000');
+        await expectInnerText(page, '#qc-flag-details-to', 'To:\n09/08/2019, 07:50:00.000');
         await expectInnerText(page, '#qc-flag-details-createdBy', 'Created by:\nJan Jansen');
         await expectInnerText(page, '#qc-flag-details-createdAt', 'Created at:\n13/02/2024, 11:57:20');
         await expectInnerText(page, '.panel div', 'Some qc comment 4');

--- a/test/public/qcFlags/forDataPassCreation.test.js
+++ b/test/public/qcFlags/forDataPassCreation.test.js
@@ -158,8 +158,8 @@ module.exports = () => {
 
         await expectRowValues(page, 1, {
             flagType: 'Limited acceptance',
-            from: '08/08/2019\n13:01:01',
-            to: '09/08/2019\n13:50:59',
+            from: '08/08/2019,\n13:01:01.000',
+            to: '09/08/2019,\n13:50:59.000',
         });
     });
 

--- a/test/public/qcFlags/forDataPassOverview.test.js
+++ b/test/public/qcFlags/forDataPassOverview.test.js
@@ -96,11 +96,12 @@ module.exports = () => {
 
         // eslint-disable-next-line jsdoc/require-param
         const validateDate = (date) => date === '-' || !isNaN(dateAndTime.parse(date, 'DD/MM/YYYY hh:mm:ss'));
+        const validateQcFlagDate = (date) => date === '-' || !isNaN(dateAndTime.parse(date, 'DD/MM/YYYY, hh:mm:ss.SSS'));
         const tableDataValidators = {
             flagType: (flagType) => flagType && flagType !== '-',
             createdBy: (userName) => userName && userName !== '-',
-            from: (timestamp) => timestamp === 'Whole run coverage' || validateDate(timestamp),
-            to: (timestamp) => timestamp === 'Whole run coverage' || validateDate(timestamp),
+            from: (timestamp) => timestamp === 'Whole run coverage' || validateQcFlagDate(timestamp),
+            to: (timestamp) => timestamp === 'Whole run coverage' || validateQcFlagDate(timestamp),
             createdAt: validateDate,
             updatedAt: validateDate,
         };

--- a/test/public/qcFlags/forSimulationPassCreation.test.js
+++ b/test/public/qcFlags/forSimulationPassCreation.test.js
@@ -154,8 +154,8 @@ module.exports = () => {
 
         await expectRowValues(page, 1, {
             flagType: 'Limited acceptance',
-            from: '08/08/2019\n13:01:01',
-            to: '09/08/2019\n13:50:59',
+            from: '08/08/2019,\n13:01:01.000',
+            to: '09/08/2019,\n13:50:59.000',
         });
     });
 

--- a/test/public/qcFlags/forSimulationPassOverview.test.js
+++ b/test/public/qcFlags/forSimulationPassOverview.test.js
@@ -97,11 +97,12 @@ module.exports = () => {
 
         // eslint-disable-next-line jsdoc/require-param
         const validateDate = (date) => date === '-' || !isNaN(dateAndTime.parse(date, 'DD/MM/YYYY hh:mm:ss'));
+        const validateQcFlagDate = (date) => date === '-' || !isNaN(dateAndTime.parse(date, 'DD/MM/YYYY, hh:mm:ss.SSS'));
         const tableDataValidators = {
             flagType: (flagType) => flagType && flagType !== '-',
             createdBy: (userName) => userName && userName !== '-',
-            from: (timestamp) => timestamp === 'Whole run coverage' || timestamp === 'From run start' || validateDate(timestamp),
-            to: (timestamp) => timestamp === 'Whole run coverage' || timestamp === 'Until run end' || validateDate(timestamp),
+            from: (timestamp) => timestamp === 'Whole run coverage' || timestamp === 'From run start' || validateQcFlagDate(timestamp),
+            to: (timestamp) => timestamp === 'Whole run coverage' || timestamp === 'Until run end' || validateQcFlagDate(timestamp),
             createdAt: validateDate,
             updatedAt: validateDate,
         };

--- a/test/public/qcFlags/gaqOverview.test.js
+++ b/test/public/qcFlags/gaqOverview.test.js
@@ -64,11 +64,11 @@ module.exports = () => {
 
     it('shows correct datatypes in respective columns', async () => {
         // eslint-disable-next-line require-jsdoc
-        const validateDate = (date) => date === '-' || !isNaN(dateAndTime.parse(date, 'DD/MM/YYYY hh:mm:ss'));
+        const validateQcFlagDate = (date) => date === '-' || !isNaN(dateAndTime.parse(date, 'DD/MM/YYYY, hh:mm:ss.SSS'));
         const tableDataValidators = {
             generalQuality: (generalQuality) => ['good', 'bad', 'MC.R', ''].includes(generalQuality),
-            from: (timestamp) => timestamp === 'Whole run coverage' || validateDate(timestamp),
-            to: (timestamp) => timestamp === 'Whole run coverage' || validateDate(timestamp),
+            from: (timestamp) => timestamp === 'Whole run coverage' || validateQcFlagDate(timestamp),
+            to: (timestamp) => timestamp === 'Whole run coverage' || validateQcFlagDate(timestamp),
         };
 
         await validateTableData(page, new Map(Object.entries(tableDataValidators)));
@@ -77,22 +77,22 @@ module.exports = () => {
         expect(await getTableContent(page)).to.have.all.deep.ordered.members([
             [
                 '',
-                '08/08/2019\n22:43:20',
-                '09/08/2019\n04:16:40',
+                '08/08/2019,\n22:43:20.000',
+                '09/08/2019,\n04:16:40.000',
                 'Limited Acceptance MC Reproducible',
                 '',
             ],
             [
                 '',
-                '09/08/2019\n05:40:00',
-                '09/08/2019\n07:03:20',
+                '09/08/2019,\n05:40:00.000',
+                '09/08/2019,\n07:03:20.000',
                 'Limited acceptance',
                 '',
             ],
             [
                 '',
-                '09/08/2019\n08:26:40',
-                '09/08/2019\n09:50:00',
+                '09/08/2019,\n08:26:40.000',
+                '09/08/2019,\n09:50:00.000',
                 'Bad',
                 '',
             ],
@@ -112,50 +112,50 @@ module.exports = () => {
         expect(await getTableContent(page)).to.have.all.deep.ordered.members([
             [
                 '',
-                '08/08/2019\n13:00:00',
-                '08/08/2019\n22:43:20',
+                '08/08/2019,\n13:00:00.000',
+                '08/08/2019,\n22:43:20.000',
                 '',
                 'Good',
             ],
             [
                 'MC.R',
-                '08/08/2019\n22:43:20',
-                '09/08/2019\n04:16:40',
+                '08/08/2019,\n22:43:20.000',
+                '09/08/2019,\n04:16:40.000',
                 'Limited Acceptance MC Reproducible',
                 'Good',
             ],
             [
                 '',
-                '09/08/2019\n04:16:40',
-                '09/08/2019\n05:40:00',
+                '09/08/2019,\n04:16:40.000',
+                '09/08/2019,\n05:40:00.000',
                 '',
                 'Good',
             ],
             [
                 'bad',
-                '09/08/2019\n05:40:00',
-                '09/08/2019\n07:03:20',
+                '09/08/2019,\n05:40:00.000',
+                '09/08/2019,\n07:03:20.000',
                 'Limited acceptance',
                 'Good',
             ],
             [
                 '',
-                '09/08/2019\n07:03:20',
-                '09/08/2019\n08:26:40',
+                '09/08/2019,\n07:03:20.000',
+                '09/08/2019,\n08:26:40.000',
                 '',
                 'Good',
             ],
             [
                 'bad',
-                '09/08/2019\n08:26:40',
-                '09/08/2019\n09:50:00',
+                '09/08/2019,\n08:26:40.000',
+                '09/08/2019,\n09:50:00.000',
                 'Bad',
                 'Good',
             ],
             [
                 '',
-                '09/08/2019\n09:50:00',
-                '09/08/2019\n14:00:00',
+                '09/08/2019,\n09:50:00.000',
+                '09/08/2019,\n14:00:00.000',
                 '',
                 'Good',
             ],

--- a/test/public/qcFlags/synchronousOverview.test.js
+++ b/test/public/qcFlags/synchronousOverview.test.js
@@ -61,14 +61,16 @@ module.exports = () => {
     it('shows correct datatypes in respective columns', async () => {
         // eslint-disable-next-line require-jsdoc
         const validateDate = (date) => date === '-' || !isNaN(dateAndTime.parse(date, 'DD/MM/YYYY, hh:mm:ss'));
+        const validateQcFlagDate = (date) => date === '-' || !isNaN(dateAndTime.parse(date, 'DD/MM/YYYY, hh:mm:ss.SSS'));
+        
         const tableDataValidators = {
             flagType: (flagType) => flagType && flagType !== '-',
             from: (cellContent) => {
                 const match = cellContent.match(/^From:\s*(.+)\nTo:\s*(.+)$/);
                 if (!match) return false;
                 const [, from, to] = match;
-                return (['Whole run coverage', 'Since run start'].includes(from) || validateDate(from))
-                    && (['Whole run coverage', 'Until run end'].includes(to) || validateDate(to));
+                return (['Whole run coverage', 'Since run start'].includes(from) || validateQcFlagDate(from))
+                    && (['Whole run coverage', 'Until run end'].includes(to) || validateQcFlagDate(to));
             },
             deleted: (value) => value === 'Yes' || value === 'No',
             createdBy: (cellContent) => {


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- qc flags details (from/to) will now be displayed with milliseconds
- when displayed in 2 lines (table view, improve visual readability by using combination of grey/strong)

Notable changes for developers:
- dateUtil and qcFlag date util functions now allow for milliseconds display

Changes made to the database:
- N/A