### PR TITLE
[O2B-1605] Use detectors rather than sync detectors as per inherited prop

### DIFF
--- a/lib/public/views/Runs/RunPerPeriod/RunsPerLhcPeriodOverviewModel.js
+++ b/lib/public/views/Runs/RunPerPeriod/RunsPerLhcPeriodOverviewModel.js
@@ -34,15 +34,14 @@ export class RunsPerLhcPeriodOverviewModel extends FixedPdpBeamTypeRunsOverviewM
         this._lhcPeriodId = null;
         this._lhcPeriodStatistics$ = new ObservableData(RemoteData.notAsked());
 
-        this._syncDetectors$ = this._setDetectorsObservable(
+        this._detectors$ = this._setDetectorsObservable(
             [rctDetectorsProvider.qc$, this._lhcPeriodStatistics$],
             ([detectors, lhcPeriodStatistics]) => {
                 const filteredDetectors = filterOutLegacyDetectorsForNewerPeriods(detectors, lhcPeriodStatistics.lhcPeriod.name);
 
-                return filteredDetectors.filter(({ type }) => [DetectorType.PHYSICAL, DetectorType.MUON_GLO].includes(type));
+                return filteredDetectors.filter(({ type }) => [DetectorType.QC_ONLY, DetectorType.PHYSICAL, DetectorType.MUON_GLO,].includes(type));
             },
         );
-        this._detectors$ = this._syncDetectors$;
         this._lhcPeriodStatistics$.bubbleTo(this);
     }
 
@@ -74,8 +73,8 @@ export class RunsPerLhcPeriodOverviewModel extends FixedPdpBeamTypeRunsOverviewM
             Other: () => null,
         });
 
-        this.registerDetectorsForQcFlagsDataExport(this._syncDetectors$);
-        this.registerObservablesQcSummaryDependsOn(this._syncDetectors$);
+        this.registerDetectorsForQcFlagsDataExport(this._detectors$);
+        this.registerObservablesQcSummaryDependsOn(this._detectors$);
 
         super.load();
     }
@@ -96,19 +95,10 @@ export class RunsPerLhcPeriodOverviewModel extends FixedPdpBeamTypeRunsOverviewM
     }
 
     /**
-     * Get all detectors for synchronous QC flags
-     *
-     * @return {RemoteData<Detector[]>} detectors
-     */
-    get syncDetectors() {
-        return this._syncDetectors$.getCurrent();
-    }
-
-    /**
      * @inheritdoc
      */
     get detectors() {
-        return this._syncDetectors$.getCurrent();
+        return this._detectors$.getCurrent();
     }
 
     /**

--- a/lib/public/views/Runs/RunPerPeriod/RunsPerLhcPeriodOverviewModel.js
+++ b/lib/public/views/Runs/RunPerPeriod/RunsPerLhcPeriodOverviewModel.js
@@ -39,7 +39,7 @@ export class RunsPerLhcPeriodOverviewModel extends FixedPdpBeamTypeRunsOverviewM
             ([detectors, lhcPeriodStatistics]) => {
                 const filteredDetectors = filterOutLegacyDetectorsForNewerPeriods(detectors, lhcPeriodStatistics.lhcPeriod.name);
 
-                return filteredDetectors.filter(({ type }) => [DetectorType.QC_ONLY, DetectorType.PHYSICAL, DetectorType.MUON_GLO,].includes(type));
+                return filteredDetectors.filter(({ type }) => [DetectorType.PHYSICAL, DetectorType.MUON_GLO].includes(type));
             },
         );
         this._lhcPeriodStatistics$.bubbleTo(this);

--- a/lib/public/views/Runs/RunPerPeriod/RunsPerLhcPeriodOverviewPage.js
+++ b/lib/public/views/Runs/RunPerPeriod/RunsPerLhcPeriodOverviewPage.js
@@ -51,7 +51,7 @@ export const RunsPerLhcPeriodOverviewPage = ({ runs: { perLhcPeriodOverviewModel
     const {
         items: remoteRuns,
         lhcPeriodStatistics: remoteLhcPeriodStatistics,
-        syncDetectors: remoteSyncDetectors,
+        detectors: remoteDetectors,
         displayOptions,
         sortModel,
         mcReproducibleAsNotBad,
@@ -115,10 +115,10 @@ export const RunsPerLhcPeriodOverviewPage = ({ runs: { perLhcPeriodOverviewModel
                 Failure: (errors) => errorAlert(errors),
                 Loading: () => spinner(),
                 Success: () => [
-                    mergeRemoteData([remoteSyncDetectors, remoteQcSummary]).match({
-                        Success: ([syncDetectors, synchronousQcSummary]) => getTableWithGivenDetectorsColumns(
+                    mergeRemoteData([remoteDetectors, remoteQcSummary]).match({
+                        Success: ([detectors, synchronousQcSummary]) => getTableWithGivenDetectorsColumns(
                             activeColumns,
-                            runDetectorsQualitiesAndSyncQcActiveColumns(syncDetectors, {
+                            runDetectorsQualitiesAndSyncQcActiveColumns(detectors, {
                                 profiles: 'runsPerLhcPeriod',
                                 qcSummary: synchronousQcSummary,
                             }),


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for developers:
- all runsPer* models now use the inherited detectors list
